### PR TITLE
Frontend game state rework

### DIFF
--- a/frontend/mock_server/server.py
+++ b/frontend/mock_server/server.py
@@ -4,6 +4,14 @@ from flask_cors import CORS
 app = Flask(__name__)
 CORS(app)
 
+state_iter = 0
+game_states = {
+    0: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    1: "rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR w KQkq - 0 1"
+}
+registrations_iter = 0
+registrations = {}
+
 @app.route('/api/mock-board')
 def mock_board():
     return jsonify({"fenString": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"})
@@ -12,15 +20,66 @@ def mock_board():
 def update_board():
     return jsonify({"arbitraryValue": True})
 
+@app.route('/api/register', methods=['POST'])
+def register():
+  global registrations
+  global registrations_iter
+
+  req = request.get_json()
+  req_user = req["username"]
+
+  registrations[req_user] = {
+      "username": req_user,
+      "email": req["email"],
+      "password": req["password"],
+      "user_id": registrations_iter
+      }
+
+  registrations_iter += 1
+
+  return jsonify(registrations[req_user]), 201
+
+
+@app.route('/api/login', methods=['POST'])
+def login():
+  global registrations
+  req = request.get_json()
+  req_user = req["username"]
+
+  if req_user in registrations.keys() and req["password"] == registrations[req_user]["password"]:
+    return jsonify({
+      "mesage": "login successful",
+      "user": registrations[req_user]})
+  else:
+    return jsonify({"error": "invalid"})
+
 @app.route('/api/game', methods=['POST'])
 def game():
+  global state_iter
+
   req = request.get_json()
+  print(req)
   action = req['action']
   if action == 'state':
-    return jsonify({"state": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"})
-  else:
-    return jsonify({"state": "rnbqkbnr/1ppppppp/p7/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"})
+    return jsonify({
+      "user": {
+        "state": game_states[min(1, state_iter)],
+        "next_moves": ["a2a3"],
+        "side": "w",
+        "white_player_id": 0,
+        "black_player_id": 1
+      }})
+  elif action == 'move':
+    state_iter += 1
+    return jsonify({
+      "user": {
+        "state": game_states[min(1, state_iter)],
+        "next_moves": ["a3a4"],
+        "side": "b",
+        "white_player_id": 0,
+        "black_player_id": 1
+      }})
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=True, port=8080)
 

--- a/frontend/src/app/features/game/components/board/board.html
+++ b/frontend/src/app/features/game/components/board/board.html
@@ -9,8 +9,8 @@
          @for (piece of piecesArray; track $index) {
             <app-piece
                 [piece]=piece
-                [style.top]="(piece.position.x * 12.5) + '%'"
-                [style.left]="(piece.position.y * 12.5) + '%'"
+                [style.top]="(piece.position.y * 12.5) + '%'"
+                [style.left]="(piece.position.x * 12.5) + '%'"
                 [boardRef]="board"
                 (moved)="onPieceMoved(piece, $event)"
                 ></app-piece>

--- a/frontend/src/app/features/game/components/board/board.html
+++ b/frontend/src/app/features/game/components/board/board.html
@@ -1,14 +1,14 @@
 <!-- Base board layout -->
 <div id="board" #board>
-    @if (boardState$ | async; as piecesArray) {
+    @if (boardPiecesObservable$ | async; as piecesArray) {
         <!-- Squares -->
         @for (square of grid; track $index) {
-            <div class="board-square" [class.dark]="isDarkSquare($index)"></div>    
+            <div class="board-square" [class.dark]="isDarkSquare($index)"></div>
         }
         <!-- Pieces -->
          @for (piece of piecesArray; track $index) {
-            <app-piece 
-                [piece]=piece 
+            <app-piece
+                [piece]=piece
                 [style.top]="(piece.position.x * 12.5) + '%'"
                 [style.left]="(piece.position.y * 12.5) + '%'"
                 [boardRef]="board"

--- a/frontend/src/app/features/game/components/board/board.spec.ts
+++ b/frontend/src/app/features/game/components/board/board.spec.ts
@@ -5,7 +5,12 @@ import { provideHttpClient } from '@angular/common/http';
 import { Board } from './board';
 import { API_ENDPOINT } from '../../../../app.constants';
 
-export const mockBoardStateResponse = { user: { "state": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"  } };
+export const mockBoardStateResponse = { user: {
+  "state": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    "next_moves": ["a2a3"],
+    "side": "w",
+    "white_player_id": 0,
+    "black_player_id": 1 } };
 
 describe('Board', () => {
   let component: Board;

--- a/frontend/src/app/features/game/components/board/board.spec.ts
+++ b/frontend/src/app/features/game/components/board/board.spec.ts
@@ -3,14 +3,8 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideHttpClient } from '@angular/common/http';
 
 import { Board } from './board';
+import { mockBoardStateResponse } from '../../services/board-state-service.spec';
 import { API_ENDPOINT } from '../../../../app.constants';
-
-export const mockBoardStateResponse = { user: {
-  "state": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-    "next_moves": ["a2a3"],
-    "side": "w",
-    "white_player_id": 0,
-    "black_player_id": 1 } };
 
 describe('Board', () => {
   let component: Board;

--- a/frontend/src/app/features/game/components/board/board.ts
+++ b/frontend/src/app/features/game/components/board/board.ts
@@ -1,6 +1,5 @@
-import { Component, effect, inject, Signal } from '@angular/core';
+import { Component, inject, Signal } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
-import { Observable } from 'rxjs';
 import { toObservable } from '@angular/core/rxjs-interop';
 
 import { BoardStateService } from '../../services/board-state-service';
@@ -26,7 +25,7 @@ export class Board {
   }
 
   onPieceMoved(piece: ChessPiece, target: Position) {
-    this.stateService.updatePiecePosition(1, 0, piece, target)
+    this.stateService.updatePiecePosition(1, 0, piece, target).subscribe();
   }
 
   isDarkSquare(i: number): boolean {

--- a/frontend/src/app/features/game/components/board/board.ts
+++ b/frontend/src/app/features/game/components/board/board.ts
@@ -17,7 +17,7 @@ export class Board {
   grid = Array.from({ length: 64 });
 
   private loadService = inject(BoardLoadService);
-  boardState$: Observable<ChessPiece[]> = this.loadService.boardLoad(1, 0);
+  boardState$: Observable<ChessPiece[]> = this.loadService.boardLoad(1, 0, 'w');
 
   constructor() {}
 

--- a/frontend/src/app/features/game/components/board/board.ts
+++ b/frontend/src/app/features/game/components/board/board.ts
@@ -1,8 +1,9 @@
-import { Component, effect, inject } from '@angular/core';
+import { Component, effect, inject, Signal } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { Observable } from 'rxjs';
+import { toObservable } from '@angular/core/rxjs-interop';
 
-import { BoardLoadService } from '../../services/board-load-service';
+import { BoardStateService } from '../../services/board-state-service';
 import { Piece } from '../piece/piece';
 import { ChessPiece } from '../../services/pieces/ChessPiece';
 import { Position } from '../../services/pieces/Position';
@@ -16,13 +17,16 @@ import { Position } from '../../services/pieces/Position';
 export class Board {
   grid = Array.from({ length: 64 });
 
-  private loadService = inject(BoardLoadService);
-  boardState$: Observable<ChessPiece[]> = this.loadService.boardLoad(1, 0, 'w');
+  private stateService = inject(BoardStateService);
+  boardPieces: Signal<ChessPiece[]> = this.stateService.pieces;
+  boardPiecesObservable$ = toObservable(this.boardPieces);
 
-  constructor() {}
+  constructor() {
+    this.stateService.boardLoad(1, 0, 'w').subscribe();
+  }
 
   onPieceMoved(piece: ChessPiece, target: Position) {
-    this.boardState$ = this.loadService.updatePiecePosition(1, 0, piece, target)
+    this.stateService.updatePiecePosition(1, 0, piece, target)
   }
 
   isDarkSquare(i: number): boolean {

--- a/frontend/src/app/features/game/components/board/board.ts
+++ b/frontend/src/app/features/game/components/board/board.ts
@@ -21,10 +21,12 @@ export class Board {
   boardPiecesObservable$ = toObservable(this.boardPieces);
 
   constructor() {
+    // TODO this needs to be replaced. Discuss @ #74 (https://github.com/dstettler/simpleboard/issues/74)
     this.stateService.boardLoad(1, 0, 'w').subscribe();
   }
 
   onPieceMoved(piece: ChessPiece, target: Position) {
+    // TODO this needs to be replaced. Discuss @ #74 (https://github.com/dstettler/simpleboard/issues/74)
     this.stateService.updatePiecePosition(1, 0, piece, target).subscribe();
   }
 

--- a/frontend/src/app/features/game/components/piece/piece.html
+++ b/frontend/src/app/features/game/components/piece/piece.html
@@ -2,6 +2,7 @@
     cdkDrag
     [cdkDragBoundary]="'#board'"
     [cdkDragFreeDragPosition]="dragPosition"
-    (cdkDragEnded)="onDragEnded($event)">
+    (cdkDragEnded)="onDragEnded($event)"
+     [cdkDragDisabled]="!piece.enabled">
     <img class="chess-piece" src="{{ piece.getImageUrl() }}" />
 </div>

--- a/frontend/src/app/features/game/components/piece/piece.ts
+++ b/frontend/src/app/features/game/components/piece/piece.ts
@@ -14,7 +14,7 @@ export class Piece {
   @Input() piece!: ChessPiece;
   @Input() boardRef!: HTMLElement;
 
-  @Output() 
+  @Output()
   moved = new EventEmitter<Position>();
 
   dragPosition = { x: 0, y: 0 };
@@ -23,15 +23,15 @@ export class Piece {
     const boardSize = this.boardRef.getBoundingClientRect();
     const squareSize = boardSize.width / 8;
 
-    const newRow = Math.round(this.piece.position.x + event.distance.y / squareSize);
-    const newCol = Math.round(this.piece.position.y + event.distance.x / squareSize);
+    const newRow = Math.round(this.piece.position.x + event.distance.x / squareSize);
+    const newCol = Math.round(this.piece.position.y + event.distance.y / squareSize);
 
     const clampedRow = Math.max(0, Math.min(7, newRow));
     const clampedCol = Math.max(0, Math.min(7, newCol));
 
     this.moved.emit(newPosition(clampedRow, clampedCol));
 
-    // This is necessary to reset cdkDrag's internal offset each time state is updated, 
+    // This is necessary to reset cdkDrag's internal offset each time state is updated,
     // since the position is determined via style in the board component.
     event.source._dragRef.reset();
   }

--- a/frontend/src/app/features/game/game.spec.ts
+++ b/frontend/src/app/features/game/game.spec.ts
@@ -1,12 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { Game } from './game';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
-import { mockBoardStateResponse } from './components/board/board.spec';
-
+import { Game } from './game';
 import { API_ENDPOINT } from '../../app.constants'
+import { mockBoardStateResponse } from './services/board-state-service.spec';
 
 describe('Game', () => {
   let component: Game;

--- a/frontend/src/app/features/game/services/BoardState.ts
+++ b/frontend/src/app/features/game/services/BoardState.ts
@@ -8,6 +8,19 @@ export interface BoardState {
     enPassant: Position|null;
     halfmoveClock: number;
     fullmoveNum: number;
+    userColor: string;
+}
+
+export function emptyState(): BoardState {
+    return {
+      pieces: [],
+      isWhiteMove: false,
+      castleables: '',
+      enPassant: null,
+      halfmoveClock: -1,
+      fullmoveNum: -1,
+      userColor: ''
+    };
 }
 
 export function mockPositions(): ChessPiece[] {

--- a/frontend/src/app/features/game/services/BoardState.ts
+++ b/frontend/src/app/features/game/services/BoardState.ts
@@ -1,6 +1,9 @@
 import { ChessPiece, Rook, Knight, Bishop, Queen, King, Pawn } from './pieces/ChessPiece';
 import { Position } from './pieces/Position';
 
+const gameStatusMembers = ["InProgress", "Waiting", "Error"] as const;
+export type GameStatus = typeof gameStatusMembers[number];
+
 export interface BoardState {
     pieces: ChessPiece[];
     isWhiteMove: boolean;
@@ -9,6 +12,17 @@ export interface BoardState {
     halfmoveClock: number;
     fullmoveNum: number;
     userColor: string;
+    nextMoves: string[];
+    gameStatus: GameStatus;
+}
+
+export function parseGameStatus(statusStr: string): GameStatus {
+  const found = gameStatusMembers.find((matched) => matched === statusStr);
+  if (found) {
+    return found;
+  }
+
+  return "Error";
 }
 
 export function emptyState(): BoardState {
@@ -19,7 +33,9 @@ export function emptyState(): BoardState {
       enPassant: null,
       halfmoveClock: -1,
       fullmoveNum: -1,
-      userColor: ''
+      userColor: '',
+      nextMoves: [],
+      gameStatus: "Waiting"
     };
 }
 

--- a/frontend/src/app/features/game/services/BoardState.ts
+++ b/frontend/src/app/features/game/services/BoardState.ts
@@ -1,20 +1,5 @@
-import { ChessPiece, Rook, Knight, Bishop, Queen, King, Pawn } from './pieces/ChessPiece';
-import { Position } from './pieces/Position';
-
 const gameStatusMembers = ["InProgress", "Waiting", "Error"] as const;
 export type GameStatus = typeof gameStatusMembers[number];
-
-export interface BoardState {
-    pieces: ChessPiece[];
-    isWhiteMove: boolean;
-    castleables: string;
-    enPassant: Position|null;
-    halfmoveClock: number;
-    fullmoveNum: number;
-    userColor: string;
-    nextMoves: string[];
-    gameStatus: GameStatus;
-}
 
 export function parseGameStatus(statusStr: string): GameStatus {
   const found = gameStatusMembers.find((matched) => matched === statusStr);
@@ -24,34 +9,3 @@ export function parseGameStatus(statusStr: string): GameStatus {
 
   return "Error";
 }
-
-export function emptyState(): BoardState {
-    return {
-      pieces: [],
-      isWhiteMove: false,
-      castleables: '',
-      enPassant: null,
-      halfmoveClock: -1,
-      fullmoveNum: -1,
-      userColor: '',
-      nextMoves: [],
-      gameStatus: "Waiting"
-    };
-}
-
-export function mockPositions(): ChessPiece[] {
-    return [
-      new Rook(0, false, 0, 0),
-      new Knight(1, false, 1, 0),
-      new Bishop(2, false, 2, 0),
-      new Queen(3, false, 3, 0),
-      new King(4, false, 4, 0),
-      new Pawn(5, false, 0, 1),
-      new Pawn(6, true, 0, 6),
-      new Rook(7, true, 0, 7),
-      new Knight(8, true, 1, 7),
-      new Bishop(9, true, 2, 7),
-      new Queen(10, true, 3, 7),
-      new King(11, true, 4, 7),
-    ]
-  }

--- a/frontend/src/app/features/game/services/BoardState.ts
+++ b/frontend/src/app/features/game/services/BoardState.ts
@@ -42,16 +42,16 @@ export function emptyState(): BoardState {
 export function mockPositions(): ChessPiece[] {
     return [
       new Rook(0, false, 0, 0),
-      new Knight(1, false, 0, 1),
-      new Bishop(2, false, 0, 2),
-      new Queen(3, false, 0, 3),
-      new King(4, false, 0, 4),
-      new Pawn(5, false, 1, 0),
-      new Pawn(6, true, 6, 0),
-      new Rook(7, true, 7, 0),
-      new Knight(8, true, 7, 1),
-      new Bishop(9, true, 7, 2),
-      new Queen(10, true, 7, 3),
-      new King(11, true, 7, 4),
+      new Knight(1, false, 1, 0),
+      new Bishop(2, false, 2, 0),
+      new Queen(3, false, 3, 0),
+      new King(4, false, 4, 0),
+      new Pawn(5, false, 0, 1),
+      new Pawn(6, true, 0, 6),
+      new Rook(7, true, 0, 7),
+      new Knight(8, true, 1, 7),
+      new Bishop(9, true, 2, 7),
+      new Queen(10, true, 3, 7),
+      new King(11, true, 4, 7),
     ]
   }

--- a/frontend/src/app/features/game/services/board-load-service.ts
+++ b/frontend/src/app/features/game/services/board-load-service.ts
@@ -3,8 +3,9 @@ import { HttpClient } from '@angular/common/http';
 import { map, Observable, switchMap } from 'rxjs';
 
 import { ChessPiece, getPieceFromFenCharacter } from './pieces/ChessPiece';
-import { Position, positionToAlgebraic } from './pieces/Position';
+import { algebraicToPosition, Position, positionToAlgebraic } from './pieces/Position';
 import { API_ENDPOINT } from '../../../app.constants';
+import { BoardState, emptyState } from './BoardState';
 
 type GameRequest = {
   action: string;
@@ -35,12 +36,12 @@ type GameApiError = {
 export class BoardLoadService {
   private http = inject(HttpClient);
 
-  positionsArray: ChessPiece[]|null = null;
+  state: BoardState|null = null;
 
   /**
    * @returns {Map<string, ChessPiece} Indexed map of pieces on board with key of "[Position.x],[Position.y]".
    */
-  boardLoad(gameId: number, playerId: number): Observable<ChessPiece[]> {
+  boardLoad(gameId: number, playerId: number, playerColor: string): Observable<ChessPiece[]> {
     // Load initial state
     const req: GameRequest = {
       action:"state",
@@ -48,6 +49,9 @@ export class BoardLoadService {
       player_id: playerId,
       move: ""
     };
+
+    this.state = emptyState();
+    this.state.userColor = playerColor;
 
     return this.gameRequest(req);
   }
@@ -60,16 +64,16 @@ export class BoardLoadService {
           const err = state as GameApiError;
           // Illegal operation
           console.error(err.error);
-          if (this.positionsArray == null) {
+          if (this.state == null) {
             return [];
           } else {
-            return this.positionsArray;
+            return this.state.pieces;
           }
         } else {
           const resp = state as ResponseUser;
           const ret = this.fenDecode(resp.user.state);
-          this.positionsArray = ret;
-          return ret;
+          this.state = ret;
+          return ret.pieces;
         }
       })
     );
@@ -77,9 +81,9 @@ export class BoardLoadService {
 
   updatePiecePosition(gameId: number, playerId: number, piece: ChessPiece, newPos: Position): Observable<ChessPiece[]> {
     let captureChar = '';
-    if (this.positionsArray) {
+    if (this.state) {
       console.log(newPos);
-      for (const piece of this.positionsArray) {
+      for (const piece of this.state.pieces) {
         const isSamePos = piece.position.x == newPos.x && piece.position.y == newPos.y;
         if (isSamePos)
           captureChar = 'x';
@@ -99,7 +103,7 @@ export class BoardLoadService {
     return this.gameRequest(req);
   }
 
-  public fenDecode(fenString: string): ChessPiece[] {
+  public fenDecode(fenString: string): BoardState {
     console.log(`fenString is as follows: ${fenString}`);
     const fenFields = fenString.split(' ');
 
@@ -108,6 +112,11 @@ export class BoardLoadService {
       const errorString = `Invalid FEN string provided by server: ${fenString}. Reason: ${validation[1]}`
       console.error(errorString);
       throw new Error(errorString);
+    }
+
+    let decodedState = this.state;
+    if (!decodedState) {
+      throw new Error("State not initialized!");
     }
 
     const placement = fenFields[0]
@@ -137,8 +146,20 @@ export class BoardLoadService {
       currentX++;
     }
 
-    this.positionsArray = pieces;
-    return pieces;
+    decodedState.pieces = pieces;
+
+    decodedState.isWhiteMove = activeColor == 'w';
+    decodedState.castleables = castleable;
+    if (enPassant != '-') {
+      decodedState.enPassant = algebraicToPosition(enPassant);
+    } else {
+      decodedState.enPassant = null;
+    }
+
+    decodedState.halfmoveClock = Number(halfmoveClock);
+    decodedState.fullmoveNum = Number(fullmoveNumber);
+
+    return decodedState;
   }
 
   private validatePlacementField(field: string): [boolean, string] {

--- a/frontend/src/app/features/game/services/board-load-service.ts
+++ b/frontend/src/app/features/game/services/board-load-service.ts
@@ -96,15 +96,7 @@ export class BoardLoadService {
       move: moveStr
     };
 
-    const stateReq: GameRequest = {
-      action: "state",
-      game_id: gameId,
-      player_id: playerId,
-      move: ''
-    };
-
-
-    return this.gameRequest(req).pipe(switchMap(() => this.gameRequest(stateReq)));
+    return this.gameRequest(req);
   }
 
   public fenDecode(fenString: string): ChessPiece[] {

--- a/frontend/src/app/features/game/services/board-state-service.spec.ts
+++ b/frontend/src/app/features/game/services/board-state-service.spec.ts
@@ -1,14 +1,49 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { BoardStateService } from './board-state-service';
-import { mockPositions } from './BoardState';
+import { ChessPiece, Rook, Knight, Bishop, Queen, King, Pawn } from './pieces/ChessPiece';
+import { positionToAlgebraic, algebraicToPosition } from './pieces/Position';
+import { API_ENDPOINT } from '../../../app.constants';
 
-describe('BoardLoadService', () => {
+export const mockBoardStateResponse = { user: {
+  "state": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    "next_moves": ["a2a3"],
+    "side": "w",
+    "white_player_id": 0,
+    "black_player_id": 1 } };
+
+function mockPositions(): ChessPiece[] {
+    return [
+      new Rook(0, false, 0, 0),
+      new Knight(1, false, 1, 0),
+      new Bishop(2, false, 2, 0),
+      new Queen(3, false, 3, 0),
+      new King(4, false, 4, 0),
+      new Pawn(5, false, 0, 1),
+      new Pawn(6, true, 0, 6),
+      new Rook(7, true, 0, 7),
+      new Knight(8, true, 1, 7),
+      new Bishop(9, true, 2, 7),
+      new Queen(10, true, 3, 7),
+      new King(11, true, 4, 7),
+    ]
+  }
+
+describe('BoardStateService', () => {
   let service: BoardStateService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
     service = TestBed.inject(BoardStateService);
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
   it('should be created', () => {
@@ -23,5 +58,33 @@ describe('BoardLoadService', () => {
     service.fenDecode(mockPositionString);
 
     expect(service.pieces()).toStrictEqual(knownPositions);
-  })
+  });
+
+  it('should load state from request', () => {
+    service.boardLoad(0, 1, 'w').subscribe(_ => {
+      expect(service.userColor()).toBe('w');
+      expect(service.fullmoveNum()).toBe(1);
+
+      // Only one next move is provided, so we can directly index this
+      expect(service.nextMoves()[0].pieceIdx).toBe(16);
+      expect(service.nextMoves()[0].targetPos).toStrictEqual({x: 0, y: 5})
+    });
+
+    const ex = httpMock.expectOne(`${API_ENDPOINT}/api/game`);
+    ex.flush(mockBoardStateResponse);
+  });
+
+  it('should decode positions properly', () => {
+    expect(algebraicToPosition('a8')).toStrictEqual({x: 0, y: 0});
+    expect(algebraicToPosition('a1')).toStrictEqual({x: 0, y: 7});
+    expect(algebraicToPosition('h8')).toStrictEqual({x: 7, y: 0});
+    expect(algebraicToPosition('h1')).toStrictEqual({x: 7, y: 7});
+  });
+
+  it('should encode positions properly', () => {
+    expect(positionToAlgebraic({x: 0, y: 0})).toBe('a8');
+    expect(positionToAlgebraic({x: 0, y: 7})).toBe('a1');
+    expect(positionToAlgebraic({x: 7, y: 0})).toBe('h8');
+    expect(positionToAlgebraic({x: 7, y: 7})).toBe('h1');
+  });
 });

--- a/frontend/src/app/features/game/services/board-state-service.spec.ts
+++ b/frontend/src/app/features/game/services/board-state-service.spec.ts
@@ -4,7 +4,7 @@ import { provideHttpClient } from '@angular/common/http';
 
 import { BoardStateService } from './board-state-service';
 import { ChessPiece, Rook, Knight, Bishop, Queen, King, Pawn } from './pieces/ChessPiece';
-import { positionToAlgebraic, algebraicToPosition } from './pieces/Position';
+import { positionToAlgebraic, algebraicToPosition, positionsEqual } from './pieces/Position';
 import { API_ENDPOINT } from '../../../app.constants';
 
 export const mockBoardStateResponse = { user: {
@@ -86,5 +86,11 @@ describe('BoardStateService', () => {
     expect(positionToAlgebraic({x: 0, y: 7})).toBe('a1');
     expect(positionToAlgebraic({x: 7, y: 0})).toBe('h8');
     expect(positionToAlgebraic({x: 7, y: 7})).toBe('h1');
+  });
+
+  it('should determine position equality properly', () => {
+    expect(positionsEqual({x: 0, y: 1}, {x: 0, y: 1})).toBe(true);
+    expect(positionsEqual({x: 0, y: 0}, {x: 0, y: 1})).toBe(false);
+    expect(positionsEqual({x: 1, y: 1}, {x: 0, y: 1})).toBe(false);
   });
 });

--- a/frontend/src/app/features/game/services/board-state-service.spec.ts
+++ b/frontend/src/app/features/game/services/board-state-service.spec.ts
@@ -1,14 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
-import { BoardLoadService } from './board-load-service';
+import { BoardStateService } from './board-state-service';
 import { mockPositions } from './BoardState';
 
 describe('BoardLoadService', () => {
-  let service: BoardLoadService;
+  let service: BoardStateService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(BoardLoadService);
+    service = TestBed.inject(BoardStateService);
   });
 
   it('should be created', () => {
@@ -20,8 +20,8 @@ describe('BoardLoadService', () => {
 
     const mockPositionString = 'rnbqk3/p7/8/8/8/8/P7/RNBQK3 b KQkq - 0 1';
 
-    const createdPositions = service.fenDecode(mockPositionString);
+    service.fenDecode(mockPositionString);
 
-    expect(createdPositions).toStrictEqual(knownPositions);
+    expect(service.pieces()).toStrictEqual(knownPositions);
   })
 });

--- a/frontend/src/app/features/game/services/board-state-service.ts
+++ b/frontend/src/app/features/game/services/board-state-service.ts
@@ -114,6 +114,7 @@ export class BoardStateService {
 
             for (const [i, piece] of this._pieces().entries()) {
               if (positionsEqual(piece.position, start)) {
+                this._pieces.update(p => { p[i].enabled = true; return p; });
                 return {pieceIdx: i, targetPos: finish};
               }
             }
@@ -131,9 +132,6 @@ export class BoardStateService {
 
   updatePiecePosition(gameId: number, playerId: number, piece: ChessPiece, newPos: Position): Observable<void> {
     let captureChar = '';
-    console.log('Moving:');
-    console.log(piece.position);
-    console.log(newPos);
     for (const piece of this._pieces()) {
       if (positionsEqual(piece.position, newPos))
         captureChar = 'x';

--- a/frontend/src/app/features/game/services/board-state-service.ts
+++ b/frontend/src/app/features/game/services/board-state-service.ts
@@ -1,11 +1,11 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, Observable, switchMap } from 'rxjs';
 
 import { ChessPiece, getPieceFromFenCharacter } from './pieces/ChessPiece';
-import { algebraicToPosition, Position, positionToAlgebraic } from './pieces/Position';
+import { algebraicToPosition, Position, positionsEqual, positionToAlgebraic } from './pieces/Position';
 import { API_ENDPOINT } from '../../../app.constants';
-import { BoardState, emptyState } from './BoardState';
+import { BoardState, emptyState, GameStatus, parseGameStatus } from './BoardState';
 
 type GameRequest = {
   action: string;
@@ -30,18 +30,45 @@ type GameApiError = {
   error: string
 }
 
+interface Move {
+  pieceIdx: number;
+  targetPos: Position;
+}
+
 @Injectable({
   providedIn: 'root',
 })
-export class BoardLoadService {
+export class BoardStateService {
   private http = inject(HttpClient);
 
-  state: BoardState|null = null;
+  private _pieces = signal<ChessPiece[]>([]);
+  private _isOwnMove = signal<boolean>(false);
+  private _castleables = signal<string>('');
+  private _enPassant = signal<Position|null>(null);
+  private _halfmoveClock = signal<number>(-1);
+  private _fullmoveNum = signal<number>(-1);
+  private _userColor = signal<string>('');
+  private _nextMoves = signal<Move[]>([]);
+  private _gameStatus = signal<GameStatus>("Waiting");
+  private _playerId = signal<number>(-1);
+  private _gameId = signal<number>(-1);
+
+  readonly pieces = this._pieces.asReadonly();
+  readonly isOwnMove = this._isOwnMove.asReadonly();
+  readonly castleables = this._castleables.asReadonly();
+  readonly enPassant = this._enPassant.asReadonly();
+  readonly halfmoveClock = this._halfmoveClock.asReadonly();
+  readonly fullmoveNum = this._fullmoveNum.asReadonly();
+  readonly userColor = this._userColor.asReadonly();
+  readonly nextMoves = this._nextMoves.asReadonly();
+  readonly gameStatus = this._gameStatus.asReadonly();
+  readonly playerId = this._playerId.asReadonly();
+  readonly gameId = this._gameId.asReadonly();
 
   /**
-   * @returns {Map<string, ChessPiece} Indexed map of pieces on board with key of "[Position.x],[Position.y]".
+   * @returns Observable<void>, so the caller may make use of the completion event after request completion and state update.
    */
-  boardLoad(gameId: number, playerId: number, playerColor: string): Observable<ChessPiece[]> {
+  boardLoad(gameId: number, playerId: number, playerColor: string): Observable<void> {
     // Load initial state
     const req: GameRequest = {
       action:"state",
@@ -50,13 +77,14 @@ export class BoardLoadService {
       move: ""
     };
 
-    this.state = emptyState();
-    this.state.userColor = playerColor;
+    this._playerId.update(_i => playerId);
+    this._gameId.update(_i => gameId);
+    this._userColor.update(_c => playerColor);
 
     return this.gameRequest(req);
   }
 
-  gameRequest(reqBody: GameRequest): Observable<ChessPiece[]> {
+  gameRequest(reqBody: GameRequest): Observable<void> {
     // Returns an observable after sequentially decoding JSON string and filtering into the map via rxjs pipe.
     return this.http.post<ResponseUser|GameApiError>(`${API_ENDPOINT}/api/game`, reqBody).pipe(
       map(state => {
@@ -64,30 +92,51 @@ export class BoardLoadService {
           const err = state as GameApiError;
           // Illegal operation
           console.error(err.error);
-          if (this.state == null) {
-            return [];
-          } else {
-            return this.state.pieces;
-          }
+          return;
         } else {
           const resp = state as ResponseUser;
-          const ret = this.fenDecode(resp.user.state);
-          this.state = ret;
-          return ret.pieces;
+          this.fenDecode(resp.user.state);
+          this._nextMoves.update(_p => resp.user.next_moves.map(move_str => {
+            let start: Position, finish: Position;
+
+            if (move_str.length == 5) {
+              // move_str == "a1xb1"
+              start = algebraicToPosition(move_str.slice(0, 2));
+              finish = algebraicToPosition(move_str.slice(3));
+            } else if (move_str.length == 4) {
+              // move_str == "a1b1"
+              start = algebraicToPosition(move_str.slice(0, 2));
+              finish = algebraicToPosition(move_str.slice(2));
+            } else {
+              console.error(`Invalid next move str: ${move_str}`);
+              throw new Error("Invalid next move str");
+            }
+
+            for (const [i, piece] of this._pieces().entries()) {
+              if (positionsEqual(piece.position, start)) {
+                return {pieceIdx: i, targetPos: finish};
+              }
+            }
+
+            console.error(`No piece found for target move ${move_str}`);
+            throw new Error(`No piece found for target move ${move_str}`);
+          }));
+;
+          this._gameStatus.update(_p => parseGameStatus(resp.user.status));
+          return;
         }
       })
     );
   }
 
-  updatePiecePosition(gameId: number, playerId: number, piece: ChessPiece, newPos: Position): Observable<ChessPiece[]> {
+  updatePiecePosition(gameId: number, playerId: number, piece: ChessPiece, newPos: Position): Observable<void> {
     let captureChar = '';
-    if (this.state) {
-      console.log(newPos);
-      for (const piece of this.state.pieces) {
-        const isSamePos = piece.position.x == newPos.x && piece.position.y == newPos.y;
-        if (isSamePos)
-          captureChar = 'x';
-      }
+    console.log('Moving:');
+    console.log(piece.position);
+    console.log(newPos);
+    for (const piece of this._pieces()) {
+      if (positionsEqual(piece.position, newPos))
+        captureChar = 'x';
     }
 
     const moveStr = `${positionToAlgebraic(piece.position)}${captureChar}${positionToAlgebraic(newPos)}`;
@@ -103,7 +152,7 @@ export class BoardLoadService {
     return this.gameRequest(req);
   }
 
-  public fenDecode(fenString: string): BoardState {
+  public fenDecode(fenString: string) {
     console.log(`fenString is as follows: ${fenString}`);
     const fenFields = fenString.split(' ');
 
@@ -112,11 +161,6 @@ export class BoardLoadService {
       const errorString = `Invalid FEN string provided by server: ${fenString}. Reason: ${validation[1]}`
       console.error(errorString);
       throw new Error(errorString);
-    }
-
-    let decodedState = this.state;
-    if (!decodedState) {
-      throw new Error("State not initialized!");
     }
 
     const placement = fenFields[0]
@@ -146,20 +190,18 @@ export class BoardLoadService {
       currentX++;
     }
 
-    decodedState.pieces = pieces;
+    this._pieces.update(_p => pieces);
 
-    decodedState.isWhiteMove = activeColor == 'w';
-    decodedState.castleables = castleable;
+    this._isOwnMove.update(_m => this.userColor() == activeColor);
+    this._castleables.update(_c => castleable);
     if (enPassant != '-') {
-      decodedState.enPassant = algebraicToPosition(enPassant);
+      this._enPassant.update(_e => algebraicToPosition(enPassant));
     } else {
-      decodedState.enPassant = null;
+      this._enPassant.update(_e => null);
     }
 
-    decodedState.halfmoveClock = Number(halfmoveClock);
-    decodedState.fullmoveNum = Number(fullmoveNumber);
-
-    return decodedState;
+    this._halfmoveClock.update(_c => Number(halfmoveClock));
+    this._fullmoveNum.update(_n => Number(fullmoveNumber));
   }
 
   private validatePlacementField(field: string): [boolean, string] {

--- a/frontend/src/app/features/game/services/board-state-service.ts
+++ b/frontend/src/app/features/game/services/board-state-service.ts
@@ -178,16 +178,17 @@ export class BoardStateService {
       for (const char of rank) {
         if (Number.isNaN(parseInt(char))) {
           pieces.push(getPieceFromFenCharacter(char, currentId, currentX, currentY));
+          console.log(`${currentX}, ${currentY}: ${char}`);
           currentId++;
-          currentY++;
+          currentX++;
         } else {
           const offset = parseInt(char);
-          currentY = currentY + offset;
+          currentX = currentX + offset;
         }
       }
 
-      currentY = 0;
-      currentX++;
+      currentX = 0;
+      currentY++;
     }
 
     this._pieces.update(_p => pieces);

--- a/frontend/src/app/features/game/services/board-state-service.ts
+++ b/frontend/src/app/features/game/services/board-state-service.ts
@@ -5,7 +5,7 @@ import { map, Observable, switchMap } from 'rxjs';
 import { ChessPiece, getPieceFromFenCharacter } from './pieces/ChessPiece';
 import { algebraicToPosition, Position, positionsEqual, positionToAlgebraic } from './pieces/Position';
 import { API_ENDPOINT } from '../../../app.constants';
-import { BoardState, emptyState, GameStatus, parseGameStatus } from './BoardState';
+import { GameStatus, parseGameStatus } from './BoardState';
 
 type GameRequest = {
   action: string;
@@ -176,7 +176,6 @@ export class BoardStateService {
       for (const char of rank) {
         if (Number.isNaN(parseInt(char))) {
           pieces.push(getPieceFromFenCharacter(char, currentId, currentX, currentY));
-          console.log(`${currentX}, ${currentY}: ${char}`);
           currentId++;
           currentX++;
         } else {
@@ -199,8 +198,8 @@ export class BoardStateService {
       this._enPassant.update(_e => null);
     }
 
-    this._halfmoveClock.update(_c => Number(halfmoveClock));
-    this._fullmoveNum.update(_n => Number(fullmoveNumber));
+    this._halfmoveClock.update(_c => halfmoveClock);
+    this._fullmoveNum.update(_n => fullmoveNumber);
   }
 
   private validatePlacementField(field: string): [boolean, string] {

--- a/frontend/src/app/features/game/services/pieces/ChessPiece.ts
+++ b/frontend/src/app/features/game/services/pieces/ChessPiece.ts
@@ -12,7 +12,6 @@ export abstract class ChessPiece {
     }
 
     abstract getClass(): string;
-    abstract getPossibleMoves(): Position[];
 
     getImageUrl(): string {
         let colorPrefix = this.isWhite ? "w" : "b";
@@ -24,21 +23,11 @@ export class Rook extends ChessPiece {
     override getClass(): string {
         return "Rook"
     }
-
-    // TODO: Implement https://github.com/dstettler/simpleboard/issues/11
-    override getPossibleMoves(): Position[] {
-        return [];
-    }
 }
 
 export class Knight extends ChessPiece {
     override getClass(): string {
         return "Knight"
-    }
-
-    // TODO: Implement https://github.com/dstettler/simpleboard/issues/11
-    override getPossibleMoves(): Position[] {
-        return [];
     }
 }
 
@@ -46,21 +35,11 @@ export class Bishop extends ChessPiece {
     override getClass(): string {
         return "Bishop"
     }
-
-    // TODO: Implement https://github.com/dstettler/simpleboard/issues/11
-    override getPossibleMoves(): Position[] {
-        return [];
-    }
 }
 
 export class Pawn extends ChessPiece {
     override getClass(): string {
         return "Pawn"
-    }
-
-    // TODO: Implement https://github.com/dstettler/simpleboard/issues/11
-    override getPossibleMoves(): Position[] {
-        return [];
     }
 }
 
@@ -68,21 +47,11 @@ export class King extends ChessPiece {
     override getClass(): string {
         return "King"
     }
-
-    // TODO: Implement https://github.com/dstettler/simpleboard/issues/11
-    override getPossibleMoves(): Position[] {
-        return [];
-    }
 }
 
 export class Queen extends ChessPiece {
     override getClass(): string {
         return "Queen"
-    }
-
-    // TODO: Implement https://github.com/dstettler/simpleboard/issues/11
-    override getPossibleMoves(): Position[] {
-        return [];
     }
 }
 

--- a/frontend/src/app/features/game/services/pieces/ChessPiece.ts
+++ b/frontend/src/app/features/game/services/pieces/ChessPiece.ts
@@ -4,11 +4,13 @@ export abstract class ChessPiece {
     id: number;
     isWhite: boolean;
     position: Position;
+    enabled: boolean;
 
     constructor(id: number, isWhite: boolean, posX: number, posY: number) {
         this.id = id;
         this.isWhite = isWhite;
         this.position = newPosition(posX, posY)
+        this.enabled = false;
     }
 
     abstract getClass(): string;

--- a/frontend/src/app/features/game/services/pieces/Position.ts
+++ b/frontend/src/app/features/game/services/pieces/Position.ts
@@ -13,3 +13,9 @@ export function newPosition(x: number, y: number): Position {
 export function positionToAlgebraic(pos: Position): string {
   return `${String.fromCharCode(97 + pos.y)}${8 - pos.x}`;
 }
+
+export function algebraicToPosition(algebraicStr: string): Position {
+  const y = algebraicStr.charCodeAt(0) - 97;
+  const x = Number(algebraicStr[1]);
+  return {x: x, y: y};
+}

--- a/frontend/src/app/features/game/services/pieces/Position.ts
+++ b/frontend/src/app/features/game/services/pieces/Position.ts
@@ -16,13 +16,10 @@ export function positionToAlgebraic(pos: Position): string {
 
 export function algebraicToPosition(algebraicStr: string): Position {
   const x = algebraicStr.toLowerCase().charCodeAt(0) - 97;
-  const y = Number(algebraicStr[1]);
-  console.log(`${algebraicStr}: ${x}, ${y}`);
+  const y = 8 - Number(algebraicStr[1]);
   return {x: x, y: y};
 }
 
 export function positionsEqual(pos1: Position, pos2: Position): boolean {
-  const ret = pos1.x == pos2.x && pos1.y == pos2.y;
-  console.log(`(${pos1.x}, ${pos2.x}), (${pos1.y}, ${pos2.y}), ${ret}`);
-  return ret;
+  return pos1.x == pos2.x && pos1.y == pos2.y;
 }

--- a/frontend/src/app/features/game/services/pieces/Position.ts
+++ b/frontend/src/app/features/game/services/pieces/Position.ts
@@ -11,7 +11,7 @@ export function newPosition(x: number, y: number): Position {
 }
 
 export function positionToAlgebraic(pos: Position): string {
-  return `${String.fromCharCode(97 + pos.y)}${8 - pos.x}`;
+  return `${String.fromCharCode(97 + pos.x)}${8 - pos.y}`;
 }
 
 export function algebraicToPosition(algebraicStr: string): Position {

--- a/frontend/src/app/features/game/services/pieces/Position.ts
+++ b/frontend/src/app/features/game/services/pieces/Position.ts
@@ -15,7 +15,14 @@ export function positionToAlgebraic(pos: Position): string {
 }
 
 export function algebraicToPosition(algebraicStr: string): Position {
-  const y = algebraicStr.charCodeAt(0) - 97;
-  const x = Number(algebraicStr[1]);
+  const x = algebraicStr.toLowerCase().charCodeAt(0) - 97;
+  const y = Number(algebraicStr[1]);
+  console.log(`${algebraicStr}: ${x}, ${y}`);
   return {x: x, y: y};
+}
+
+export function positionsEqual(pos1: Position, pos2: Position): boolean {
+  const ret = pos1.x == pos2.x && pos1.y == pos2.y;
+  console.log(`(${pos1.x}, ${pos2.x}), (${pos1.y}, ${pos2.y}), ${ret}`);
+  return ret;
 }


### PR DESCRIPTION
Closes #68.

### Changes
- Rework game state. State is now stored in `board-state-service` (renamed from `board-load-service`). Rather than being a single JSON object that is mutated and passed around, state is stored in the service itself as individual signals. Observables are now directly subscribed when called, since they mutate the state as side-effects, and the signal in the Board class automatically updates a derived observable when state changes.
- Piece enable/disable logic. Pieces are now automatically disabled (not draggable) unless they are included in the next_moves array.
- Mock server updates:
  - Mock server now provides schema closer to accurate backend responses.
  - Mock server will respond to the first performed move, and will hold registration/login data.
- Fixes x and y being inverted in game logic.
- Added new unit tests.