### PR TITLE
Timer

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -34,12 +34,14 @@ The server starts on port **8080** by default.
 
 ## Environment Variables
 
-| Variable       | Default                  | Description                    |
-|----------------|--------------------------|--------------------------------|
-| `PORT`         | `8080`                   | HTTP server port               |
-| `DB_PATH`      | `./simpleboard.db`       | SQLite database file path      |
-| `CORS_ORIGINS` | `http://localhost:4200`  | Comma-separated allowed origins|
-| `JWT_SECRET`   | `no-secret`              | JWT Auth Secret Key            |
+| Variable                       | Default                  | Description                              |
+|--------------------------------|--------------------------|------------------------------------------|
+| `PORT`                         | `8080`                   | HTTP server port                         |
+| `DB_PATH`                      | `./simpleboard.db`       | SQLite database file path                |
+| `CORS_ORIGINS`                 | `http://localhost:4200`  | Comma-separated allowed origins          |
+| `JWT_SECRET`                   | `no-secret`              | JWT Auth Secret Key                      |
+| `DEFAULT_TIME_CONTROL_SECONDS` | `600`                    | Default per-side clock for new games (s) |
+| `SWEEP_INTERVAL_SECONDS`       | `30`                     | Background flag-fall sweep interval (s)  |
 
 ## API Endpoints
 
@@ -124,9 +126,11 @@ The JWT token is given upon a successful login, and expires in 24 hours.
   "action": "create",
   "player_id": 1,
   "other_id": 2,
-  "starting_side": "w"
+  "starting_side": "w",
+  "time_control_seconds": 600
 }
 ```
+`time_control_seconds` is **optional**. Omit (or send `0`) to use the server default (`DEFAULT_TIME_CONTROL_SECONDS`, 10 min). Both sides get the same starting clock.
 
 #### Response
 ```
@@ -141,6 +145,11 @@ The JWT token is given upon a successful login, and expires in 24 hours.
             "side":"w",
             "state":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
             "status":"InProgress",
+            "time_control_seconds": 600,
+            "white_remaining_ms": 600000,
+            "black_remaining_ms": 600000,
+            "last_move_at": "2026-03-26T01:27:40.740472882-04:00",
+            "server_time": "2026-03-26T01:27:40.740472882-04:00",
             "updated_at":"2026-03-26T01:27:40.740472882-04:00",
             "white_player_id":1
         }
@@ -169,11 +178,17 @@ The JWT token is given upon a successful login, and expires in 24 hours.
             "side":"w",
             "state":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
             "status":"InProgress",
+            "time_control_seconds": 600,
+            "white_remaining_ms": 597230,
+            "black_remaining_ms": 600000,
+            "last_move_at": "2026-03-26T01:27:40.740472882-04:00",
+            "server_time": "2026-03-26T01:27:43.973102000-04:00",
             "updated_at":"2026-03-26T01:27:40.740472882-04:00",
             "white_player_id":1
         }
 }
 ```
+The remaining-ms values returned for `state` are **live**: the active side's clock is computed as `stored - (server_time - last_move_at)`. Re-poll periodically and the active side's number will keep dropping. The inactive side's number is the stored value.
 
 #### Example Body
 ```
@@ -189,7 +204,7 @@ The JWT token is given upon a successful login, and expires in 24 hours.
 ```
 {
     "message":"move applied",
-        "user": {
+        "state": {
             "black_player_id":2,
             "created_at":"2026-03-26T01:27:40.740472882-04:00",
             "game_id":1,
@@ -198,8 +213,81 @@ The JWT token is given upon a successful login, and expires in 24 hours.
             "side":"b",
             "state":"rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR b KQkq - 1 1",
             "status":"InProgress",
+            "time_control_seconds": 600,
+            "white_remaining_ms": 594120,
+            "black_remaining_ms": 600000,
+            "last_move_at": "2026-03-26T01:33:52.383454683-04:00",
+            "server_time": "2026-03-26T01:33:52.391204000-04:00",
             "updated_at":"2026-03-26T01:33:52.383454683-04:00",
             "white_player_id":1
         }
 }
 ```
+On a successful move, the responding side has switched (`side` is now the opponent), the moving player's elapsed time has been deducted from their clock, and `last_move_at` jumps to the move time. If the moving player's clock had already run out, the response instead has `"message":"flag fall"` and `status` is set to `WinWhite` or `WinBlack` -- the move is **not** applied in that case.
+
+## Game Timer (frontend integration)
+
+Every game now carries a per-side chess clock. The server is the source of truth -- it decides when a player has run out of time, so clients can never cheat by stalling. This section is everything the frontend needs to render and use it.
+
+### State payload fields
+
+Every `create` / `state` / `move` response includes these on the `state` object:
+
+| Field                  | Type      | Meaning                                                                  |
+|------------------------|-----------|--------------------------------------------------------------------------|
+| `time_control_seconds` | int       | Starting clock per side (e.g. `600` = 10 min)                            |
+| `white_remaining_ms`   | int       | White's remaining time, in milliseconds                                  |
+| `black_remaining_ms`   | int       | Black's remaining time, in milliseconds                                  |
+| `last_move_at`         | timestamp | When the active side's clock started ticking (game start, or last move)  |
+| `server_time`          | timestamp | Server's current time at the moment of response (for drift correction)   |
+| `side`                 | `"w"`/`"b"` | Whose turn it is -- this is the side whose clock is currently ticking  |
+| `status`               | string    | `InProgress`, `Draw`, `WinWhite`, `WinBlack` (last two cover flag falls) |
+
+The remaining-ms values are **already live** at the moment of response: for the side whose clock is ticking, the server has already subtracted `(server_time - last_move_at)` before sending. You don't need to re-do that math on receipt.
+
+### Rendering a smooth countdown between polls
+
+Polling every second would waste bandwidth. The recommended pattern:
+
+1. On each response, capture `serverTime` and `lastMoveAt` from the payload, plus the local clock time `t0 = Date.now()` at receipt.
+2. For the **active side** (`side` field), display:
+   ```
+   activeRemainingMs - (Date.now() - t0)
+   ```
+   (i.e. start a local 1-second tick and decrement smoothly)
+3. For the **inactive side**, just display the stored remaining ms (it's frozen).
+4. Re-poll `state` every ~5-10 seconds to resync against drift, or after every move you receive.
+
+`server_time` exists so you can detect clock drift between client and server -- if you want to be robust, anchor display time to `server_time` rather than `Date.now()`.
+
+### Setting a custom time control
+
+When calling `action: "create"`, optionally pass `time_control_seconds`. Examples:
+
+| Mode    | Seconds |
+|---------|---------|
+| Bullet  | `60` or `120` |
+| Blitz   | `180` or `300` |
+| Rapid   | `600` (default) or `900` |
+| Classical | `1800`+ |
+
+Omit the field, send `0`, or send a negative value -> server falls back to `DEFAULT_TIME_CONTROL_SECONDS` (10 min).
+
+### What happens when a clock runs out
+
+1. **During a move**: if the moving player's flag has fallen, the server returns `"message":"flag fall"`, sets `status` to `WinWhite` or `WinBlack`, and the move is **rejected** (board state is unchanged).
+2. **During a state poll**: if the active side has run out while idle, the server marks the game as ended and returns the final status. Clients see `status` flip from `InProgress` to `WinWhite` / `WinBlack` between polls.
+3. **With nobody polling**: a background sweeper goroutine scans in-progress games every `SWEEP_INTERVAL_SECONDS` (default 30s) and ends any whose active side has flag-fallen. So a game can't sit alive forever just because both browsers were closed.
+
+After flag fall, the loser's `*_remaining_ms` is `0`. The opponent's number is whatever was stored at the moment of the loss.
+
+### Status values to watch for
+
+| Status       | Meaning                                                               |
+|--------------|-----------------------------------------------------------------------|
+| `InProgress` | Game is live, clocks tick on the active side                          |
+| `Draw`       | Stalemate / 50-move rule / etc.                                       |
+| `WinWhite`   | White wins (checkmate, resignation, **or black flag-fell on time**)   |
+| `WinBlack`   | Black wins (checkmate, resignation, **or white flag-fell on time**)   |
+
+The status string alone doesn't tell you whether a win was by checkmate or by time -- if you need to differentiate in the UI, check whether the loser's `*_remaining_ms` is `0` at game end.

--- a/backend/env.sh.template
+++ b/backend/env.sh.template
@@ -21,3 +21,10 @@ export CORS_ORIGINS="http://localhost:4200"
 
 # JWT secret
 export JWT_SECRET="secret-key"
+
+# Timer total default in seconds
+export DEFAULT_TIME_CONTROL_SECONDS=600
+
+# Sweep interval in seconds;
+# Interval to sweep the games table to correct out-of-time entries
+export SWEEP_INTERVAL_SECONDS=30

--- a/backend/simpleboard/cmd/simpleboard/main.go
+++ b/backend/simpleboard/cmd/simpleboard/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"log"
 	"net/http"
+	"time"
 
 	"simpleboard/api"
 	"simpleboard/internal/auth"
+	"simpleboard/internal/timer"
 	"simpleboard/pkg/config"
 	"simpleboard/pkg/db"
 )
@@ -17,8 +19,15 @@ func main() {
 	// initialize auth middleware
 	auth.Init(cfg)
 
+	// load timer defaults from config
+	timer.Init(cfg)
+
 	// connect the db
 	db.Connect(cfg)
+
+	// kick off background sweeper that ends games whose clocks ran out
+	// even if no one is polling them
+	timer.StartSweeper(db.DB, time.Duration(cfg.SweepIntervalSeconds)*time.Second)
 
 	// register API routes
 	router := api.RegisterRoutes()

--- a/backend/simpleboard/internal/domain/game.go
+++ b/backend/simpleboard/internal/domain/game.go
@@ -16,13 +16,10 @@ type Game struct {
 	Side          string
 	NextMoves     []string
 	PrevMoves     []string
-
-	// Per-side chess clock; only the active side's time ticks down
 	TimeControlSeconds int
 	WhiteRemainingMs   int64
 	BlackRemainingMs   int64
 	LastMoveAt         time.Time
-
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/backend/simpleboard/internal/domain/game.go
+++ b/backend/simpleboard/internal/domain/game.go
@@ -16,6 +16,13 @@ type Game struct {
 	Side          string
 	NextMoves     []string
 	PrevMoves     []string
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+
+	// Per-side chess clock; only the active side's time ticks down
+	TimeControlSeconds int
+	WhiteRemainingMs   int64
+	BlackRemainingMs   int64
+	LastMoveAt         time.Time
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }

--- a/backend/simpleboard/internal/handler/game.go
+++ b/backend/simpleboard/internal/handler/game.go
@@ -108,7 +108,7 @@ func Game(c *gin.Context) {
 		}
 
 		// stamp initial clock state; white's time starts ticking from now
-		timer.InitGame(&entry, input.TimeControlSeconds, time.Now())
+		timer.InitGameTime(&entry, input.TimeControlSeconds, time.Now())
 
 		// create entry
 		if err := db.DB.Create(&entry).Error; err != nil {

--- a/backend/simpleboard/internal/handler/game.go
+++ b/backend/simpleboard/internal/handler/game.go
@@ -2,12 +2,13 @@ package handler
 
 import (
 	"encoding/json"
-	//"fmt"
 	"net/http"
+	"time"
 
 	"simpleboard/internal/auth"
 	"simpleboard/internal/chess"
 	"simpleboard/internal/repository"
+	"simpleboard/internal/timer"
 	"simpleboard/pkg/db"
 
 	"github.com/gin-gonic/gin"
@@ -17,13 +18,14 @@ import (
 // Game endpoint
 func Game(c *gin.Context) {
 	var input struct {
-		Action       string `json:"action"`
-		GameID       int    `json:"game_id"`
-		PlayerID     uint   `json:"player_id"`
-		GuestID      string `json:"guest_id"`
-		OtherID      uint   `json:"other_id"`
-		Move         string `json:"move"`
-		StartingSide string `json:"starting_side"`
+		Action             string `json:"action"`
+		GameID             int    `json:"game_id"`
+		PlayerID           uint   `json:"player_id"`
+		GuestID            string `json:"guest_id"`
+		OtherID            uint   `json:"other_id"`
+		Move               string `json:"move"`
+		StartingSide       string `json:"starting_side"`
+		TimeControlSeconds int    `json:"time_control_seconds"`
 	}
 
 	// bad request; could not bind context into input struct
@@ -105,6 +107,9 @@ func Game(c *gin.Context) {
 			PrevMoves:     prevMovesJSON,
 		}
 
+		// stamp initial clock state; white's time starts ticking from now
+		timer.InitGame(&entry, input.TimeControlSeconds, time.Now())
+
 		// create entry
 		if err := db.DB.Create(&entry).Error; err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -114,20 +119,7 @@ func Game(c *gin.Context) {
 		// game successfully added
 		c.JSON(http.StatusCreated, gin.H{
 			"message": "game created",
-			"state": gin.H{
-				"game_id":         entry.ID,
-				"white_player_id": entry.WhitePlayerID,
-				"black_player_id": entry.BlackPlayerID,
-				"white_guest_id":  entry.WhiteGuestID,
-				"black_guest_id":  entry.BlackGuestID,
-				"state":           entry.State,
-				"status":          entry.Status,
-				"side":            entry.Side,
-				"next_moves":      entry.NextMoves,
-				"prev_moves":      entry.PrevMoves,
-				"created_at":      entry.CreatedAt,
-				"updated_at":      entry.UpdatedAt,
-			},
+			"state":   gameStatePayload(&entry, entry.WhiteRemainingMs, entry.BlackRemainingMs),
 		})
 	} else if action == "state" {
 
@@ -152,22 +144,22 @@ func Game(c *gin.Context) {
 			return
 		}
 
+		// compute authoritative clocks; if active side flag-fell while polling,
+		// persist the timeout result so a refresh sees the final state
+		whiteMs, blackMs, timedOut, loser := timer.LiveRemaining(&entry, time.Now())
+		if timedOut {
+			entry.Status = timer.FlagFallStatus(loser).String()
+			if loser == "w" {
+				entry.WhiteRemainingMs = 0
+			} else {
+				entry.BlackRemainingMs = 0
+			}
+			db.DB.Save(&entry)
+		}
+
 		c.JSON(http.StatusOK, gin.H{
 			"message": "state",
-			"state": gin.H{
-				"game_id":         entry.ID,
-				"white_player_id": entry.WhitePlayerID,
-				"black_player_id": entry.BlackPlayerID,
-				"white_guest_id":  entry.WhiteGuestID,
-				"black_guest_id":  entry.BlackGuestID,
-				"state":           entry.State,
-				"status":          entry.Status,
-				"side":            entry.Side,
-				"next_moves":      entry.NextMoves,
-				"prev_moves":      entry.PrevMoves,
-				"created_at":      entry.CreatedAt,
-				"updated_at":      entry.UpdatedAt,
-			},
+			"state":   gameStatePayload(&entry, whiteMs, blackMs),
 		})
 	} else if action == "move" {
 
@@ -213,6 +205,18 @@ func Game(c *gin.Context) {
 			return
 		}
 
+		// deduct the moving side's elapsed time first; if their flag fell,
+		// they lose on time and the move is never applied
+		if timedOut, loser := timer.ApplyMove(&entry, time.Now()); timedOut {
+			entry.Status = timer.FlagFallStatus(loser).String()
+			db.DB.Save(&entry)
+			c.JSON(http.StatusOK, gin.H{
+				"message": "flag fall",
+				"state":   gameStatePayload(&entry, entry.WhiteRemainingMs, entry.BlackRemainingMs),
+			})
+			return
+		}
+
 		game := chess.ReadChessGame(entry.State, moves, prevmoves)
 
 		moveErr := game.Move(input.Move)
@@ -237,46 +241,47 @@ func Game(c *gin.Context) {
 		prevMovesData, _ := json.Marshal(prevMovesStr)
 		prevMovesJSON := datatypes.JSON(prevMovesData)
 
-		updatedEntry := repository.Game{
-			ID:            uint(input.GameID),
-			WhitePlayerID: uint(entry.WhitePlayerID),
-			BlackPlayerID: uint(entry.BlackPlayerID),
-			WhiteGuestID:  entry.WhiteGuestID,
-			BlackGuestID:  entry.BlackGuestID,
-			State:         game.FEN(),
-			Status:        game.Status.String(),
-			Side:          game.Side,
-			NextMoves:     nextMovesJSON,
-			PrevMoves:     prevMovesJSON,
-		}
+		// update in place so timer fields (already mutated by ApplyMove) persist
+		entry.State = game.FEN()
+		entry.Status = game.Status.String()
+		entry.Side = game.Side
+		entry.NextMoves = nextMovesJSON
+		entry.PrevMoves = prevMovesJSON
 
-		db.DB.Save(&updatedEntry)
-
-		if err := db.DB.Where("id = ?", input.GameID).First(&entry).Error; err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid game id"})
-			return
-		}
+		db.DB.Save(&entry)
 
 		c.JSON(http.StatusOK, gin.H{
 			"message": "move applied",
-			"state": gin.H{
-				"game_id":         entry.ID,
-				"white_player_id": entry.WhitePlayerID,
-				"black_player_id": entry.BlackPlayerID,
-				"white_guest_id":  entry.WhiteGuestID,
-				"black_guest_id":  entry.BlackGuestID,
-				"state":           entry.State,
-				"status":          entry.Status,
-				"side":            entry.Side,
-				"next_moves":      entry.NextMoves,
-				"prev_moves":      entry.PrevMoves,
-				"created_at":      entry.CreatedAt,
-				"updated_at":      entry.UpdatedAt,
-			},
+			"state":   gameStatePayload(&entry, entry.WhiteRemainingMs, entry.BlackRemainingMs),
 		})
 	} else {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid action"})
 		return
+	}
+}
+
+// builds the JSON state object returned to clients; whiteMs/blackMs are the
+// authoritative live clocks (computed by the caller, may differ from stored
+// values when the active side's time is still ticking)
+func gameStatePayload(entry *repository.Game, whiteMs, blackMs int64) gin.H {
+	return gin.H{
+		"game_id":              entry.ID,
+		"white_player_id":      entry.WhitePlayerID,
+		"black_player_id":      entry.BlackPlayerID,
+		"white_guest_id":       entry.WhiteGuestID,
+		"black_guest_id":       entry.BlackGuestID,
+		"state":                entry.State,
+		"status":               entry.Status,
+		"side":                 entry.Side,
+		"next_moves":           entry.NextMoves,
+		"prev_moves":           entry.PrevMoves,
+		"time_control_seconds": entry.TimeControlSeconds,
+		"white_remaining_ms":   whiteMs,
+		"black_remaining_ms":   blackMs,
+		"last_move_at":         entry.LastMoveAt,
+		"server_time":          time.Now().UTC(),
+		"created_at":           entry.CreatedAt,
+		"updated_at":           entry.UpdatedAt,
 	}
 }
 

--- a/backend/simpleboard/internal/repository/game_model.go
+++ b/backend/simpleboard/internal/repository/game_model.go
@@ -8,7 +8,7 @@ import (
 // Game is an instance of an active game session
 // Stores player IDs, game state, and timestamps
 type Game struct {
-	ID            uint           `gorm:"uniqueIndex;primaryKey;autoIncrement`
+	ID            uint           `gorm:"uniqueIndex;primaryKey;autoIncrement"`
 	WhitePlayerID uint           `json:"white_player_id"`
 	BlackPlayerID uint           `json:"black_player_id"`
 	WhiteGuestID  string         `json:"white_guest_id"`

--- a/backend/simpleboard/internal/repository/game_model.go
+++ b/backend/simpleboard/internal/repository/game_model.go
@@ -18,6 +18,13 @@ type Game struct {
 	Side          string         `gorm:"size:1; not null"`
 	NextMoves     datatypes.JSON `gorm:"type:json"`
 	PrevMoves     datatypes.JSON `gorm:"type:json"`
-	CreatedAt     time.Time      `json:"created_at"`
-	UpdatedAt     time.Time      `json:"updated_at"`
+
+	// Per-side chess clock; only the active side's time ticks down
+	TimeControlSeconds int       `json:"time_control_seconds"`
+	WhiteRemainingMs   int64     `json:"white_remaining_ms"`
+	BlackRemainingMs   int64     `json:"black_remaining_ms"`
+	LastMoveAt         time.Time `json:"last_move_at"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/backend/simpleboard/internal/repository/game_model.go
+++ b/backend/simpleboard/internal/repository/game_model.go
@@ -18,13 +18,10 @@ type Game struct {
 	Side          string         `gorm:"size:1; not null"`
 	NextMoves     datatypes.JSON `gorm:"type:json"`
 	PrevMoves     datatypes.JSON `gorm:"type:json"`
-
-	// Per-side chess clock; only the active side's time ticks down
 	TimeControlSeconds int       `json:"time_control_seconds"`
 	WhiteRemainingMs   int64     `json:"white_remaining_ms"`
 	BlackRemainingMs   int64     `json:"black_remaining_ms"`
 	LastMoveAt         time.Time `json:"last_move_at"`
-
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/backend/simpleboard/internal/timer/sweeper.go
+++ b/backend/simpleboard/internal/timer/sweeper.go
@@ -31,7 +31,6 @@ func StartSweeper(db *gorm.DB, interval time.Duration) {
 }
 
 // sweepOnce does a single pass over in-progress games and ends timed-out ones.
-// Pulled out so it's easy to invoke directly from a test.
 func sweepOnce(db *gorm.DB, now time.Time) {
 	var games []repository.Game
 	if err := db.Where("status = ?", chess.InProgress.String()).Find(&games).Error; err != nil {
@@ -41,22 +40,30 @@ func sweepOnce(db *gorm.DB, now time.Time) {
 
 	for i := range games {
 		g := &games[i]
-		_, _, timedOut, loser := LiveRemaining(g, now)
-		if !timedOut {
+		if !markIfTimedOut(g, now) {
 			continue
 		}
-
-		g.Status = FlagFallStatus(loser).String()
-		if loser == "w" {
-			g.WhiteRemainingMs = 0
-		} else {
-			g.BlackRemainingMs = 0
-		}
-
 		if err := db.Save(g).Error; err != nil {
 			log.Printf("timer sweeper: save game %d failed: %v", g.ID, err)
 			continue
 		}
-		log.Printf("timer sweeper: game %d ended on time (%s flagged)", g.ID, loser)
+		log.Printf("timer sweeper: game %d ended on time", g.ID)
 	}
+}
+
+// markIfTimedOut applies the flag-fall result to a single game in place.
+// Returns true if the game was modified (and therefore needs to be persisted).
+// Pure function -- no DB needed -- so it's straightforward to test.
+func markIfTimedOut(g *repository.Game, now time.Time) bool {
+	_, _, timedOut, loser := LiveRemaining(g, now)
+	if !timedOut {
+		return false
+	}
+	g.Status = FlagFallStatus(loser).String()
+	if loser == "w" {
+		g.WhiteRemainingMs = 0
+	} else {
+		g.BlackRemainingMs = 0
+	}
+	return true
 }

--- a/backend/simpleboard/internal/timer/sweeper.go
+++ b/backend/simpleboard/internal/timer/sweeper.go
@@ -1,0 +1,62 @@
+package timer
+
+import (
+	"log"
+	"time"
+
+	"simpleboard/internal/chess"
+	"simpleboard/internal/repository"
+
+	"gorm.io/gorm"
+)
+
+// StartSweeper launches a background goroutine that periodically scans
+// in-progress games and ends any whose active side has flag-fallen.
+// This guarantees a game can't sit forever just because no one is polling.
+func StartSweeper(db *gorm.DB, interval time.Duration) {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		log.Printf("Timer sweeper running every %s", interval)
+
+		for range ticker.C {
+			sweepOnce(db, time.Now())
+		}
+	}()
+}
+
+// sweepOnce does a single pass over in-progress games and ends timed-out ones.
+// Pulled out so it's easy to invoke directly from a test.
+func sweepOnce(db *gorm.DB, now time.Time) {
+	var games []repository.Game
+	if err := db.Where("status = ?", chess.InProgress.String()).Find(&games).Error; err != nil {
+		log.Printf("timer sweeper: query failed: %v", err)
+		return
+	}
+
+	for i := range games {
+		g := &games[i]
+		_, _, timedOut, loser := LiveRemaining(g, now)
+		if !timedOut {
+			continue
+		}
+
+		g.Status = FlagFallStatus(loser).String()
+		if loser == "w" {
+			g.WhiteRemainingMs = 0
+		} else {
+			g.BlackRemainingMs = 0
+		}
+
+		if err := db.Save(g).Error; err != nil {
+			log.Printf("timer sweeper: save game %d failed: %v", g.ID, err)
+			continue
+		}
+		log.Printf("timer sweeper: game %d ended on time (%s flagged)", g.ID, loser)
+	}
+}

--- a/backend/simpleboard/internal/timer/sweeper_test.go
+++ b/backend/simpleboard/internal/timer/sweeper_test.go
@@ -1,0 +1,68 @@
+package timer
+
+import (
+	"testing"
+	"time"
+
+	"simpleboard/internal/chess"
+	"simpleboard/internal/repository"
+)
+
+func TestMarkIfTimedOut_FlagsWhiteOutOfTime(t *testing.T) {
+	now := time.Now()
+	g := &repository.Game{
+		Status:           chess.InProgress.String(),
+		Side:             "w",
+		WhiteRemainingMs: 100,
+		BlackRemainingMs: 60_000,
+		LastMoveAt:       now.Add(-5 * time.Second),
+	}
+
+	changed := markIfTimedOut(g, now)
+	if !changed {
+		t.Fatal("expected timeout to be marked")
+	}
+	if g.Status != chess.WinBlack.String() {
+		t.Errorf("status = %q, want WinBlack", g.Status)
+	}
+	if g.WhiteRemainingMs != 0 {
+		t.Errorf("white remaining = %d, want 0", g.WhiteRemainingMs)
+	}
+}
+
+func TestMarkIfTimedOut_LeavesActiveGameAlone(t *testing.T) {
+	now := time.Now()
+	g := &repository.Game{
+		Status:           chess.InProgress.String(),
+		Side:             "b",
+		WhiteRemainingMs: 60_000,
+		BlackRemainingMs: 60_000,
+		LastMoveAt:       now.Add(-1 * time.Second),
+	}
+
+	if markIfTimedOut(g, now) {
+		t.Fatal("active game wrongly flagged as timed out")
+	}
+	if g.Status != chess.InProgress.String() {
+		t.Errorf("status changed to %q on a non-timeout", g.Status)
+	}
+}
+
+func TestMarkIfTimedOut_IgnoresFinishedGames(t *testing.T) {
+	now := time.Now()
+	// stale clocks would normally flag, but the game is already won
+	g := &repository.Game{
+		Status:           chess.WinWhite.String(),
+		Side:             "b",
+		WhiteRemainingMs: 30_000,
+		BlackRemainingMs: 100,
+		LastMoveAt:       now.Add(-10 * time.Minute),
+	}
+
+	if markIfTimedOut(g, now) {
+		t.Fatal("finished game must not be re-flagged")
+	}
+	if g.Status != chess.WinWhite.String() {
+		t.Errorf("status = %q, want WinWhite (untouched)", g.Status)
+	}
+}

--- a/backend/simpleboard/internal/timer/timer.go
+++ b/backend/simpleboard/internal/timer/timer.go
@@ -26,8 +26,8 @@ func DefaultControlSeconds() int {
 	return defaultControlSeconds
 }
 
-// InitGame stamps initial clock state on a new game
-func InitGame(g *repository.Game, controlSeconds int, now time.Time) {
+// InitGameTime stamps initial clock state on a new game
+func InitGameTime(g *repository.Game, controlSeconds int, now time.Time) {
 	if controlSeconds <= 0 {
 		controlSeconds = defaultControlSeconds
 	}

--- a/backend/simpleboard/internal/timer/timer.go
+++ b/backend/simpleboard/internal/timer/timer.go
@@ -1,0 +1,110 @@
+// Package timer enforces per-side chess clocks server-side.
+// The active side's clock ticks down between moves; when it hits
+// zero the player flag-falls and loses on time.
+package timer
+
+import (
+	"time"
+
+	"simpleboard/internal/chess"
+	"simpleboard/internal/repository"
+	"simpleboard/pkg/config"
+)
+
+// Default 10 min/side; overridden by config.Init
+var defaultControlSeconds = 600
+
+// Init wires runtime defaults from config
+func Init(cfg *config.Config) {
+	if cfg.DefaultTimeControlSeconds > 0 {
+		defaultControlSeconds = cfg.DefaultTimeControlSeconds
+	}
+}
+
+// DefaultControlSeconds returns the configured default time control
+func DefaultControlSeconds() int {
+	return defaultControlSeconds
+}
+
+// InitGame stamps initial clock state on a new game
+func InitGame(g *repository.Game, controlSeconds int, now time.Time) {
+	if controlSeconds <= 0 {
+		controlSeconds = defaultControlSeconds
+	}
+	ms := int64(controlSeconds) * 1000
+
+	g.TimeControlSeconds = controlSeconds
+	g.WhiteRemainingMs = ms
+	g.BlackRemainingMs = ms
+	g.LastMoveAt = now
+}
+
+// LiveRemaining returns the up-to-date clock for both sides as of `now`.
+// If the active side has flag-fallen, timedOut=true and the loser side ("w"/"b")
+// is returned. Does NOT mutate the entry.
+func LiveRemaining(g *repository.Game, now time.Time) (whiteMs, blackMs int64, timedOut bool, loser string) {
+	whiteMs = g.WhiteRemainingMs
+	blackMs = g.BlackRemainingMs
+
+	// clock is frozen for finished games
+	if g.Status != chess.InProgress.String() {
+		return
+	}
+
+	elapsedMs := now.Sub(g.LastMoveAt).Milliseconds()
+	if elapsedMs < 0 {
+		elapsedMs = 0
+	}
+
+	if g.Side == "w" {
+		whiteMs -= elapsedMs
+		if whiteMs <= 0 {
+			whiteMs = 0
+			timedOut = true
+			loser = "w"
+		}
+	} else {
+		blackMs -= elapsedMs
+		if blackMs <= 0 {
+			blackMs = 0
+			timedOut = true
+			loser = "b"
+		}
+	}
+	return
+}
+
+// ApplyMove deducts elapsed time from the side that just moved and rolls
+// LastMoveAt forward. Call BEFORE switching sides on the chess engine.
+// Returns true and the loser side if the moving player flag-fell.
+func ApplyMove(g *repository.Game, now time.Time) (timedOut bool, loser string) {
+	elapsedMs := now.Sub(g.LastMoveAt).Milliseconds()
+	if elapsedMs < 0 {
+		elapsedMs = 0
+	}
+
+	if g.Side == "w" {
+		g.WhiteRemainingMs -= elapsedMs
+		if g.WhiteRemainingMs <= 0 {
+			g.WhiteRemainingMs = 0
+			return true, "w"
+		}
+	} else {
+		g.BlackRemainingMs -= elapsedMs
+		if g.BlackRemainingMs <= 0 {
+			g.BlackRemainingMs = 0
+			return true, "b"
+		}
+	}
+
+	g.LastMoveAt = now
+	return false, ""
+}
+
+// FlagFallStatus maps the losing side to a chess.Status (the opponent wins)
+func FlagFallStatus(loser string) chess.Status {
+	if loser == "w" {
+		return chess.WinBlack
+	}
+	return chess.WinWhite
+}

--- a/backend/simpleboard/internal/timer/timer_test.go
+++ b/backend/simpleboard/internal/timer/timer_test.go
@@ -20,11 +20,11 @@ func newGame(side string, whiteMs, blackMs int64, lastMove time.Time) *repositor
 	}
 }
 
-func TestInitGame_UsesProvidedControl(t *testing.T) {
+func TestInitGameTime_UsesProvidedControl(t *testing.T) {
 	g := &repository.Game{}
 	now := time.Now()
 
-	InitGame(g, 300, now)
+	InitGameTime(g, 300, now)
 
 	if g.TimeControlSeconds != 300 {
 		t.Errorf("TimeControlSeconds = %d, want 300", g.TimeControlSeconds)
@@ -37,17 +37,17 @@ func TestInitGame_UsesProvidedControl(t *testing.T) {
 	}
 }
 
-func TestInitGame_FallsBackToDefaultWhenZeroOrNegative(t *testing.T) {
+func TestInitGameTime_FallsBackToDefaultWhenZeroOrNegative(t *testing.T) {
 	defaultControlSeconds = 600 // ensure baseline
 	g := &repository.Game{}
 
-	InitGame(g, 0, time.Now())
+	InitGameTime(g, 0, time.Now())
 	if g.TimeControlSeconds != 600 {
 		t.Errorf("zero input: got %d, want 600 (default)", g.TimeControlSeconds)
 	}
 
 	g2 := &repository.Game{}
-	InitGame(g2, -5, time.Now())
+	InitGameTime(g2, -5, time.Now())
 	if g2.TimeControlSeconds != 600 {
 		t.Errorf("negative input: got %d, want 600 (default)", g2.TimeControlSeconds)
 	}

--- a/backend/simpleboard/internal/timer/timer_test.go
+++ b/backend/simpleboard/internal/timer/timer_test.go
@@ -1,0 +1,177 @@
+package timer
+
+import (
+	"testing"
+	"time"
+
+	"simpleboard/internal/chess"
+	"simpleboard/internal/repository"
+)
+
+// helper to build a fresh in-progress game with a known clock state
+func newGame(side string, whiteMs, blackMs int64, lastMove time.Time) *repository.Game {
+	return &repository.Game{
+		Status:             chess.InProgress.String(),
+		Side:               side,
+		TimeControlSeconds: 600,
+		WhiteRemainingMs:   whiteMs,
+		BlackRemainingMs:   blackMs,
+		LastMoveAt:         lastMove,
+	}
+}
+
+func TestInitGame_UsesProvidedControl(t *testing.T) {
+	g := &repository.Game{}
+	now := time.Now()
+
+	InitGame(g, 300, now)
+
+	if g.TimeControlSeconds != 300 {
+		t.Errorf("TimeControlSeconds = %d, want 300", g.TimeControlSeconds)
+	}
+	if g.WhiteRemainingMs != 300_000 || g.BlackRemainingMs != 300_000 {
+		t.Errorf("clocks = (%d, %d), want (300000, 300000)", g.WhiteRemainingMs, g.BlackRemainingMs)
+	}
+	if !g.LastMoveAt.Equal(now) {
+		t.Errorf("LastMoveAt = %v, want %v", g.LastMoveAt, now)
+	}
+}
+
+func TestInitGame_FallsBackToDefaultWhenZeroOrNegative(t *testing.T) {
+	defaultControlSeconds = 600 // ensure baseline
+	g := &repository.Game{}
+
+	InitGame(g, 0, time.Now())
+	if g.TimeControlSeconds != 600 {
+		t.Errorf("zero input: got %d, want 600 (default)", g.TimeControlSeconds)
+	}
+
+	g2 := &repository.Game{}
+	InitGame(g2, -5, time.Now())
+	if g2.TimeControlSeconds != 600 {
+		t.Errorf("negative input: got %d, want 600 (default)", g2.TimeControlSeconds)
+	}
+}
+
+func TestApplyMove_DeductsActiveSideOnly(t *testing.T) {
+	now := time.Now()
+	// white to move, last move 2s ago
+	g := newGame("w", 60_000, 60_000, now.Add(-2*time.Second))
+
+	timedOut, _ := ApplyMove(g, now)
+	if timedOut {
+		t.Fatal("unexpected flag fall")
+	}
+
+	// white should lose ~2000ms; black untouched
+	if g.WhiteRemainingMs > 58_100 || g.WhiteRemainingMs < 57_900 {
+		t.Errorf("white remaining = %d, want ~58000", g.WhiteRemainingMs)
+	}
+	if g.BlackRemainingMs != 60_000 {
+		t.Errorf("black remaining = %d, want 60000 (untouched)", g.BlackRemainingMs)
+	}
+	if !g.LastMoveAt.Equal(now) {
+		t.Errorf("LastMoveAt should advance to now")
+	}
+}
+
+func TestApplyMove_FlagFall(t *testing.T) {
+	now := time.Now()
+	// black has 500ms left, last moved 2s ago -> flag falls
+	g := newGame("b", 60_000, 500, now.Add(-2*time.Second))
+
+	timedOut, loser := ApplyMove(g, now)
+	if !timedOut {
+		t.Fatal("expected flag fall")
+	}
+	if loser != "b" {
+		t.Errorf("loser = %q, want b", loser)
+	}
+	if g.BlackRemainingMs != 0 {
+		t.Errorf("black remaining = %d, want 0", g.BlackRemainingMs)
+	}
+}
+
+func TestApplyMove_ClampsBackwardClockSkew(t *testing.T) {
+	now := time.Now()
+	// LastMoveAt is in the future -> elapsed would be negative
+	g := newGame("w", 60_000, 60_000, now.Add(5*time.Second))
+
+	timedOut, _ := ApplyMove(g, now)
+	if timedOut {
+		t.Fatal("unexpected flag fall")
+	}
+	if g.WhiteRemainingMs != 60_000 {
+		t.Errorf("white remaining = %d, want 60000 (no negative deduction)", g.WhiteRemainingMs)
+	}
+}
+
+func TestLiveRemaining_DoesNotMutate(t *testing.T) {
+	now := time.Now()
+	g := newGame("w", 60_000, 60_000, now.Add(-3*time.Second))
+
+	originalWhite := g.WhiteRemainingMs
+	originalBlack := g.BlackRemainingMs
+	originalLast := g.LastMoveAt
+
+	_, _, _, _ = LiveRemaining(g, now)
+
+	if g.WhiteRemainingMs != originalWhite || g.BlackRemainingMs != originalBlack {
+		t.Error("LiveRemaining mutated stored clocks")
+	}
+	if !g.LastMoveAt.Equal(originalLast) {
+		t.Error("LiveRemaining mutated LastMoveAt")
+	}
+}
+
+func TestLiveRemaining_ComputesActiveSide(t *testing.T) {
+	now := time.Now()
+	g := newGame("b", 60_000, 60_000, now.Add(-4*time.Second))
+
+	whiteMs, blackMs, timedOut, _ := LiveRemaining(g, now)
+	if timedOut {
+		t.Fatal("unexpected timeout")
+	}
+	if whiteMs != 60_000 {
+		t.Errorf("white = %d, want 60000 (inactive)", whiteMs)
+	}
+	if blackMs > 56_100 || blackMs < 55_900 {
+		t.Errorf("black = %d, want ~56000", blackMs)
+	}
+}
+
+func TestLiveRemaining_FrozenWhenGameFinished(t *testing.T) {
+	now := time.Now()
+	g := newGame("w", 1_000, 60_000, now.Add(-10*time.Second))
+	g.Status = chess.WinBlack.String() // already finished
+
+	whiteMs, blackMs, timedOut, _ := LiveRemaining(g, now)
+	if timedOut {
+		t.Error("finished game should not flag-fall")
+	}
+	if whiteMs != 1_000 || blackMs != 60_000 {
+		t.Errorf("clocks should be frozen, got (%d, %d)", whiteMs, blackMs)
+	}
+}
+
+func TestLiveRemaining_DetectsFlagFall(t *testing.T) {
+	now := time.Now()
+	g := newGame("w", 100, 60_000, now.Add(-2*time.Second))
+
+	whiteMs, _, timedOut, loser := LiveRemaining(g, now)
+	if !timedOut || loser != "w" {
+		t.Fatalf("expected white flag fall, got timedOut=%v loser=%q", timedOut, loser)
+	}
+	if whiteMs != 0 {
+		t.Errorf("white live remaining = %d, want 0", whiteMs)
+	}
+}
+
+func TestFlagFallStatus(t *testing.T) {
+	if FlagFallStatus("w") != chess.WinBlack {
+		t.Error("white flagged should give WinBlack")
+	}
+	if FlagFallStatus("b") != chess.WinWhite {
+		t.Error("black flagged should give WinWhite")
+	}
+}

--- a/backend/simpleboard/internal/timer/timer_test.md
+++ b/backend/simpleboard/internal/timer/timer_test.md
@@ -1,0 +1,71 @@
+
+# Running Tests
+From the module root (`backend/simpleboard/`):
+
+```bash
+# run all timer package tests
+go test ./internal/timer/
+
+# verbose output
+go test -v ./internal/timer/
+
+# run a specific test
+go test -v -run TestApplyMove_FlagFall ./internal/timer/
+
+# run all tests for a specific function area
+go test -v -run TestApplyMove   ./internal/timer/
+go test -v -run TestLiveRemaining ./internal/timer/
+go test -v -run TestMarkIfTimedOut ./internal/timer/
+```
+
+The timer package is CGO-free: every test runs against in-memory structs, no SQLite driver required. `go test ./internal/timer/...` works on a clean Go install with no extra toolchain.
+
+
+### InitGame
+
+| Test                                            | What it checks
+|-------------------------------------------------|----------------
+| TestInitGame_UsesProvidedControl                | Provided control value sets TimeControlSeconds, both clocks = control * 1000 ms, LastMoveAt = `now`
+| TestInitGame_FallsBackToDefaultWhenZeroOrNegative | Zero and negative inputs both fall back to the package default (600s)
+
+
+### ApplyMove
+
+| Test                                  | What it checks
+|---------------------------------------|----------------
+| TestApplyMove_DeductsActiveSideOnly   | White-to-move with 2s elapsed: white's clock drops by ~2000ms, black's clock untouched, LastMoveAt advances to `now`
+| TestApplyMove_FlagFall                | Black has 500ms left and 2s have elapsed: returns `(true, "b")`, BlackRemainingMs clamped to 0
+| TestApplyMove_ClampsBackwardClockSkew | LastMoveAt set in the future (clock skew): elapsed treated as 0, no negative deduction
+
+
+### LiveRemaining
+
+| Test                                | What it checks
+|-------------------------------------|----------------
+| TestLiveRemaining_DoesNotMutate     | Stored WhiteRemainingMs, BlackRemainingMs, and LastMoveAt are untouched after the call
+| TestLiveRemaining_ComputesActiveSide | Black to move with 4s elapsed: returned black ms ≈ stored - 4000, white ms = stored (frozen)
+| TestLiveRemaining_FrozenWhenGameFinished | Status = WinBlack: returned values match stored, timedOut is false even with stale clocks
+| TestLiveRemaining_DetectsFlagFall   | White has 100ms left and 2s have elapsed: returns timedOut=true, loser="w", whiteMs=0
+
+
+### FlagFallStatus
+
+| Test               | What it checks
+|--------------------|----------------
+| TestFlagFallStatus | `"w"` -> `chess.WinBlack`, `"b"` -> `chess.WinWhite`
+
+
+### markIfTimedOut (sweeper helper)
+
+| Test                                  | What it checks
+|---------------------------------------|----------------
+| TestMarkIfTimedOut_FlagsWhiteOutOfTime | White-to-move with 100ms left and 5s elapsed: returns true, Status set to WinBlack, WhiteRemainingMs zeroed
+| TestMarkIfTimedOut_LeavesActiveGameAlone | Plenty of time on both clocks, recent move: returns false, Status stays InProgress
+| TestMarkIfTimedOut_IgnoresFinishedGames | Already-won game with stale clocks: returns false, Status stays WinWhite, no clock fields rewritten
+
+
+## Test design notes
+
+- The pure helpers (`InitGame`, `ApplyMove`, `LiveRemaining`, `FlagFallStatus`, `markIfTimedOut`) operate on `*repository.Game` structs in memory, so all 13 tests run without spinning up SQLite or any other dependency.
+- `markIfTimedOut` was extracted from `sweepOnce` specifically so the per-game decision logic can be unit-tested without a real database. The DB-coupled `sweepOnce` itself is a thin loop (query -> apply -> save) and is left to integration testing.
+- The `_ClampsBackwardClockSkew` and `_DoesNotMutate` cases guard properties that are easy to regress on -- negative durations and accidental writes through the live-clock helper. Worth keeping if anyone refactors the timer math.

--- a/backend/simpleboard/internal/timer/timer_test.md
+++ b/backend/simpleboard/internal/timer/timer_test.md
@@ -21,12 +21,12 @@ go test -v -run TestMarkIfTimedOut ./internal/timer/
 The timer package is CGO-free: every test runs against in-memory structs, no SQLite driver required. `go test ./internal/timer/...` works on a clean Go install with no extra toolchain.
 
 
-### InitGame
+### InitGameTime
 
 | Test                                            | What it checks
 |-------------------------------------------------|----------------
-| TestInitGame_UsesProvidedControl                | Provided control value sets TimeControlSeconds, both clocks = control * 1000 ms, LastMoveAt = `now`
-| TestInitGame_FallsBackToDefaultWhenZeroOrNegative | Zero and negative inputs both fall back to the package default (600s)
+| TestInitGameTime_UsesProvidedControl                | Provided control value sets TimeControlSeconds, both clocks = control * 1000 ms, LastMoveAt = `now`
+| TestInitGameTime_FallsBackToDefaultWhenZeroOrNegative | Zero and negative inputs both fall back to the package default (600s)
 
 
 ### ApplyMove
@@ -66,6 +66,6 @@ The timer package is CGO-free: every test runs against in-memory structs, no SQL
 
 ## Test design notes
 
-- The pure helpers (`InitGame`, `ApplyMove`, `LiveRemaining`, `FlagFallStatus`, `markIfTimedOut`) operate on `*repository.Game` structs in memory, so all 13 tests run without spinning up SQLite or any other dependency.
+- The pure helpers (`InitGameTime`, `ApplyMove`, `LiveRemaining`, `FlagFallStatus`, `markIfTimedOut`) operate on `*repository.Game` structs in memory, so all 13 tests run without spinning up SQLite or any other dependency.
 - `markIfTimedOut` was extracted from `sweepOnce` specifically so the per-game decision logic can be unit-tested without a real database. The DB-coupled `sweepOnce` itself is a thin loop (query -> apply -> save) and is left to integration testing.
 - The `_ClampsBackwardClockSkew` and `_DoesNotMutate` cases guard properties that are easy to regress on -- negative durations and accidental writes through the live-clock helper. Worth keeping if anyone refactors the timer math.

--- a/backend/simpleboard/pkg/config/config.go
+++ b/backend/simpleboard/pkg/config/config.go
@@ -13,6 +13,10 @@ type Config struct {
 	DBPath        string
 	CORSOrigins   []string
 	JWTSecret     string
+
+	// Timer config (issue #85)
+	DefaultTimeControlSeconds int
+	SweepIntervalSeconds      int
 }
 
 // Loads the config by getting env defined variables
@@ -25,6 +29,10 @@ func Load() *Config {
 		DBPath:        getEnv("DB_PATH", "./simpleboard.db"),
 		CORSOrigins:   getEnvList("CORS_ORIGINS", []string{"http://localhost:4200"}),
 		JWTSecret:     getEnv("JWT_SECRET", "no-secret"),
+
+		// Default 10 min/side; sweeper runs every 30s
+		DefaultTimeControlSeconds: getEnvInt("DEFAULT_TIME_CONTROL_SECONDS", 600),
+		SweepIntervalSeconds:      getEnvInt("SWEEP_INTERVAL_SECONDS", 30),
 	}
 }
 

--- a/backend/simpleboard/pkg/config/config.go
+++ b/backend/simpleboard/pkg/config/config.go
@@ -13,8 +13,6 @@ type Config struct {
 	DBPath        string
 	CORSOrigins   []string
 	JWTSecret     string
-
-	// Timer config (issue #85)
 	DefaultTimeControlSeconds int
 	SweepIntervalSeconds      int
 }
@@ -29,8 +27,6 @@ func Load() *Config {
 		DBPath:        getEnv("DB_PATH", "./simpleboard.db"),
 		CORSOrigins:   getEnvList("CORS_ORIGINS", []string{"http://localhost:4200"}),
 		JWTSecret:     getEnv("JWT_SECRET", "no-secret"),
-
-		// Default 10 min/side; sweeper runs every 30s
 		DefaultTimeControlSeconds: getEnvInt("DEFAULT_TIME_CONTROL_SECONDS", 600),
 		SweepIntervalSeconds:      getEnvInt("SWEEP_INTERVAL_SECONDS", 30),
 	}


### PR DESCRIPTION
**Timer documentation :** 

1. backend/README.md
2. backend/simpleboard/internal/timer/timer_test.md

---

Recap of every **backend changes :**

- internal/repository/game_model.go
    * Added per-side clock fields.

- internal/domain/game.go
    * Mirrored the same four timer fields on the domain type so both layers stay aligned.

- pkg/config/config.go
    * Added DefaultTimeControlSeconds and SweepIntervalSeconds to the Config struct + Load().

- internal/timer/timer.go (new)
    * Houses all clock logic

- internal/timer/sweeper.go (new)
    * StartSweeper goroutine + sweepOnce DB pass; 
    * per-game decision extracted into the pure markIfTimedOut helper

- internal/handler/game.go
    * "create" stamps initial clock state via timer.InitGame and accepts
      an optional time_control_seconds override on the request body.
    * "move" calls timer.ApplyMove before validating the move; if the
      mover's flag fell, the game ends on time and the move is rejected
      with a "flag fall" message.
    * "state" returns authoritative live clocks via timer.LiveRemaining
      plus a server_time field for client drift correction; persists
      the timeout result if the active side flagged while idle.
    * Move handler now updates `entry` in place rather than rebuilding a
      fresh repository.Game struct, so the timer fields survive the save.
    * Extracted gameStatePayload helper to dedupe the response shape
      across all three actions and to centralize the timer fields.

- cmd/simpleboard/main.go
    * Wires timer.Init(cfg) after auth init, and launches timer.StartSweeper after the DB connects.

- internal/timer/timer_test.go + sweeper_test.go (new)
    * 13 pure-Go unit tests