### PR TITLE
Daily streak

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -107,7 +107,7 @@ source ./env.sh
             "user_id":  0,
             "username": "example",
             "email":    "example@example.com"
-            }
+        }
 }
 ```
 
@@ -122,15 +122,18 @@ source ./env.sh
 ```
 
 #### Response
+
 ```
 {
     "message": "login successful",
-        "token": "new-jwt-token",
+        "token": <new-jwt-token>,
         "user": {
-            "user_id":  1,
+            "user_id": 1,
             "username": "example",
-            "email":    "example@example.com"
-            }
+            "email": "example@example.com",
+            "current_streak": 4,
+            "longest_streak": 12
+        }
 }
 ```
 
@@ -293,9 +296,9 @@ The JWT token is given upon a successful login or guest user creation, and expir
 #### Example Body
 ```
 {
-  "action": "join",
-  "game_id": "f0e510f2-0d72-4ce2-ab38-025e224c55c0", // game with existing white player
-  "player_id": 2,
+    "action": "join",
+    "game_id": "f0e510f2-0d72-4ce2-ab38-025e224c55c0", // game with existing white player
+    "player_id": 2,
 }
 ```
 
@@ -328,9 +331,9 @@ The JWT token is given upon a successful login or guest user creation, and expir
 #### Example Body
 ```
 {
-  "action": "state",
-  "game_id": "f0e510f2-0d72-4ce2-ab38-025e224c55c0",
-  "player_id": 1
+    "action": "state",
+    "game_id": "f0e510f2-0d72-4ce2-ab38-025e224c55c0",
+    "player_id": 1
 }
 ```
 
@@ -364,10 +367,10 @@ The remaining-ms values returned for `state` are **live**: the active side's clo
 #### Example Body
 ```
 {
-  "action": "move",
-  "player_id": 1,
-  "game_id": "f0e510f2-0d72-4ce2-ab38-025e224c55c0",
-  "move":"a2a3"
+    "action": "move",
+    "player_id": 1,
+    "game_id": "f0e510f2-0d72-4ce2-ab38-025e224c55c0",
+    "move":"a2a3"
 }
 ```
 
@@ -473,21 +476,21 @@ These three endpoints back the dashboard and streak features. All require a regi
 
 ---
 
-### Updated: POST `/api/login` response
+### POST `/api/login` response
 
-The login response now includes streak fields so the UI can show the streak immediately after sign-in without a second request.
+The login response includes streak fields so the UI can show the streak immediately after sign-in without a second request.
 
-```json
+```
 {
-  "message": "login successful",
-  "token": "<jwt>",
-  "user": {
-    "user_id": 1,
-    "username": "alice",
-    "email": "alice@example.com",
-    "current_streak": 4,
-    "longest_streak": 12
-  }
+    "message": "login successful",
+        "token": <new-jwt-token>,
+        "user": {
+            "user_id": 1,
+            "username": "example",
+            "email": "example@example.com",
+            "current_streak": 4,
+            "longest_streak": 12
+        }
 }
 ```
 
@@ -503,16 +506,16 @@ Authorization: Bearer <token>
 ```
 
 **Response**
-```json
+```
 {
-  "user_id":        1,
-  "username":       "alice",
-  "total_games":    38,
-  "wins":           20,
-  "losses":         14,
-  "win_rate":       0.526,
-  "current_streak": 4,
-  "longest_streak": 12
+    "user_id":        1,
+    "username":       "example",
+    "total_games":    38,
+    "wins":           20,
+    "losses":         14,
+    "win_rate":       0.526,
+    "current_streak": 4,
+    "longest_streak": 12
 }
 ```
 
@@ -539,25 +542,25 @@ Authorization: Bearer <token>
 ```
 
 **Response**
-```json
+```
 {
-  "user_id": 1,
-  "games": [
+    "user_id": 1,
+    "games": [
     {
-      "game_id":     "f0e510f2-0d72-4ce2-ab38-025e224c55c0",
-      "status":      "WinWhite",
-      "played_as":   "w",
-      "opponent_id": 2,
-      "created_at":  "2026-04-28T14:00:00Z",
-      "updated_at":  "2026-04-28T14:22:00Z"
+        "game_id":     "f0e510f2-0d72-4ce2-ab38-025e224c55c0",
+        "status":      "WinWhite",
+        "played_as":   "w",
+        "opponent_id": 2,
+        "created_at":  "2026-04-28T14:00:00Z",
+        "updated_at":  "2026-04-28T14:22:00Z"
     },
     {
-      "game_id":     "a1b2c3d4-...",
-      "status":      "WinBlack",
-      "played_as":   "b",
-      "opponent_id": 0,
-      "created_at":  "2026-04-27T10:00:00Z",
-      "updated_at":  "2026-04-27T10:31:00Z"
+        "game_id":     "a1b2c3d4-...",
+        "status":      "WinBlack",
+        "played_as":   "b",
+        "opponent_id": 0,
+        "created_at":  "2026-04-27T10:00:00Z",
+        "updated_at":  "2026-04-27T10:31:00Z"
     }
   ]
 }

--- a/backend/README.md
+++ b/backend/README.md
@@ -53,13 +53,15 @@ source ./env.sh
 
 ## API Endpoints
 
-| Method | Path           | Description          |
-|--------|----------------|----------------------|
-| GET    | `/api/health`  | Health check         |
-| GET    | `/api/guest`   | Generate a guest id  |
-| POST   | `/api/register`| Register account     |
-| POST   | `/api/login`   | Login to account     |
-| POST   | `/api/game`    | Game interaction     |
+| Method | Path             | Auth required | Description                      |
+|--------|------------------|---------------|----------------------------------|
+| GET    | `/api/health`    | No            | Health check                     |
+| GET    | `/api/guest`     | No            | Generate a guest token           |
+| POST   | `/api/register`  | No            | Register a new account           |
+| POST   | `/api/login`     | No            | Login, returns token + streak    |
+| POST   | `/api/game`      | Yes           | Create / join / poll / move      |
+| GET    | `/api/dashboard` | Yes (user)    | Lifetime stats for current user  |
+| GET    | `/api/games`     | Yes (user)    | Game history for current user    |
 
 ## Usage
 
@@ -462,3 +464,158 @@ After flag fall, the loser's `*_remaining_ms` is `0`. The opponent's number is w
 | `WinBlack`   | Black wins (checkmate, resignation, **or white flag-fell on time**)   |
 
 The status string alone doesn't tell you whether a win was by checkmate or by time -- if you need to differentiate in the UI, check whether the loser's `*_remaining_ms` is `0` at game end.
+
+---
+
+## User Stats, Game History & Daily Streak
+
+These three endpoints back the dashboard and streak features (#41, #43, #86). All require a registered user token — guests get `401`.
+
+---
+
+### Updated: POST `/api/login` response
+
+The login response now includes streak fields so the UI can show the streak immediately after sign-in without a second request.
+
+```json
+{
+  "message": "login successful",
+  "token": "<jwt>",
+  "user": {
+    "user_id": 1,
+    "username": "alice",
+    "email": "alice@example.com",
+    "current_streak": 4,
+    "longest_streak": 12
+  }
+}
+```
+
+---
+
+### GET `/api/dashboard` → `200`
+
+Returns lifetime stats for the currently authenticated user.
+
+**Headers**
+```
+Authorization: Bearer <token>
+```
+
+**Response**
+```json
+{
+  "user_id":        1,
+  "username":       "alice",
+  "total_games":    38,
+  "wins":           20,
+  "losses":         14,
+  "win_rate":       0.526,
+  "current_streak": 4,
+  "longest_streak": 12
+}
+```
+
+| Field            | Type    | Notes                                             |
+|------------------|---------|---------------------------------------------------|
+| `total_games`    | int     | All completed games (wins + losses + draws)       |
+| `wins`           | int     | Games won                                         |
+| `losses`         | int     | Games lost                                        |
+| `win_rate`       | float64 | `wins / total_games`; `0.0` if no games yet       |
+| `current_streak` | int     | Consecutive days logged in ending today           |
+| `longest_streak` | int     | All-time best streak                              |
+
+> **Note:** `total_games` counts draws too, so `wins + losses` may be less than `total_games`.
+
+---
+
+### GET `/api/games` → `200`
+
+Returns the authenticated user's game history, newest first.
+
+**Headers**
+```
+Authorization: Bearer <token>
+```
+
+**Response**
+```json
+{
+  "user_id": 1,
+  "games": [
+    {
+      "game_id":     "f0e510f2-0d72-4ce2-ab38-025e224c55c0",
+      "status":      "WinWhite",
+      "played_as":   "w",
+      "opponent_id": 2,
+      "created_at":  "2026-04-28T14:00:00Z",
+      "updated_at":  "2026-04-28T14:22:00Z"
+    },
+    {
+      "game_id":     "a1b2c3d4-...",
+      "status":      "WinBlack",
+      "played_as":   "b",
+      "opponent_id": 0,
+      "created_at":  "2026-04-27T10:00:00Z",
+      "updated_at":  "2026-04-27T10:31:00Z"
+    }
+  ]
+}
+```
+
+| Field         | Type   | Notes                                                   |
+|---------------|--------|---------------------------------------------------------|
+| `game_id`     | string | UUID of the game                                        |
+| `status`      | string | `NotStarted`, `InProgress`, `Draw`, `WinWhite`, `WinBlack` |
+| `played_as`   | string | `"w"` or `"b"` — which side this user played            |
+| `opponent_id` | uint   | The other player's user ID; `0` if they were a guest    |
+| `created_at`  | string | ISO 8601 timestamp                                      |
+| `updated_at`  | string | ISO 8601 timestamp — effectively when the game ended    |
+
+---
+
+### How the daily streak works
+
+The streak is **login-based**: it increments once per calendar day (UTC midnight boundary) when the user logs in.
+
+| Scenario                         | Effect                          |
+|----------------------------------|---------------------------------|
+| First ever login                 | `current_streak = 1`            |
+| Login on a day after yesterday   | `current_streak += 1`           |
+| Login again on the same day      | No change (already counted)     |
+| Skip a day and log in            | `current_streak` resets to `1`  |
+| New streak exceeds longest       | `longest_streak` is updated     |
+
+`current_streak` and `longest_streak` are returned in both the `/api/login` response and `/api/dashboard` — show whichever fits the UI context.
+
+**Game stats** (`wins`, `losses`, `total_games`) update automatically the moment a game ends — checkmate, stalemate, 50-move draw, or flag fall. Guest players don't accumulate stats; only registered accounts do.
+
+---
+
+### Suggested frontend model
+
+```typescript
+interface DashboardResponse {
+  user_id:        number;
+  username:       string;
+  total_games:    number;
+  wins:           number;
+  losses:         number;
+  win_rate:       number;   // 0.0–1.0
+  current_streak: number;
+  longest_streak: number;
+}
+
+interface GameHistoryEntry {
+  game_id:     string;
+  status:      'NotStarted' | 'InProgress' | 'Draw' | 'WinWhite' | 'WinBlack';
+  played_as:   'w' | 'b';
+  opponent_id: number;      // 0 = guest opponent
+  created_at:  string;
+  updated_at:  string;
+}
+
+interface GamesResponse {
+  user_id: number;
+  games:   GameHistoryEntry[];
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -469,7 +469,7 @@ The status string alone doesn't tell you whether a win was by checkmate or by ti
 
 ## User Stats, Game History & Daily Streak
 
-These three endpoints back the dashboard and streak features (#41, #43, #86). All require a registered user token — guests get `401`.
+These three endpoints back the dashboard and streak features. All require a registered user token — guests get `401`.
 
 ---
 
@@ -576,15 +576,7 @@ Authorization: Bearer <token>
 
 ### How the daily streak works
 
-The streak is **login-based**: it increments once per calendar day (UTC midnight boundary) when the user logs in.
-
-| Scenario                         | Effect                          |
-|----------------------------------|---------------------------------|
-| First ever login                 | `current_streak = 1`            |
-| Login on a day after yesterday   | `current_streak += 1`           |
-| Login again on the same day      | No change (already counted)     |
-| Skip a day and log in            | `current_streak` resets to `1`  |
-| New streak exceeds longest       | `longest_streak` is updated     |
+The streak is **login-based**: it increments once per calendar day when the user logs in.
 
 `current_streak` and `longest_streak` are returned in both the `/api/login` response and `/api/dashboard` — show whichever fits the UI context.
 
@@ -592,30 +584,3 @@ The streak is **login-based**: it increments once per calendar day (UTC midnight
 
 ---
 
-### Suggested frontend model
-
-```typescript
-interface DashboardResponse {
-  user_id:        number;
-  username:       string;
-  total_games:    number;
-  wins:           number;
-  losses:         number;
-  win_rate:       number;   // 0.0–1.0
-  current_streak: number;
-  longest_streak: number;
-}
-
-interface GameHistoryEntry {
-  game_id:     string;
-  status:      'NotStarted' | 'InProgress' | 'Draw' | 'WinWhite' | 'WinBlack';
-  played_as:   'w' | 'b';
-  opponent_id: number;      // 0 = guest opponent
-  created_at:  string;
-  updated_at:  string;
-}
-
-interface GamesResponse {
-  user_id: number;
-  games:   GameHistoryEntry[];
-}

--- a/backend/simpleboard/api/routes.go
+++ b/backend/simpleboard/api/routes.go
@@ -26,6 +26,7 @@ func RegisterRoutes() *gin.Engine {
 	r.POST("/api/register", handler.Register)
 	r.POST("/api/login", handler.Login)
 	r.POST("/api/game", handler.Game)
+	r.GET("/api/dashboard", handler.Dashboard)
 
 	return r
 }

--- a/backend/simpleboard/api/routes.go
+++ b/backend/simpleboard/api/routes.go
@@ -27,6 +27,7 @@ func RegisterRoutes() *gin.Engine {
 	r.POST("/api/login", handler.Login)
 	r.POST("/api/game", handler.Game)
 	r.GET("/api/dashboard", handler.Dashboard)
+	r.GET("/api/games", handler.Games)
 
 	return r
 }

--- a/backend/simpleboard/internal/chess/engine.go
+++ b/backend/simpleboard/internal/chess/engine.go
@@ -588,27 +588,34 @@ func (g *ChessGame) IsAttacked(r, f int) bool {
 					break
 				}
 
+				// check if enemy piece is an attacking piece
+				isAttacker := false
 				if white {
 					if a == "Q" {
-						return true
-					} // queen
+						isAttacker = true
+					}
 					if a == "B" && (v[0] != 0 && v[1] != 0) {
-						return true
-					} // diagonal path
+						isAttacker = true
+					}
 					if a == "R" && (v[0] == 0 || v[1] == 0) {
-						return true
-					} // straight path
+						isAttacker = true
+					}
 				} else {
 					if a == "q" {
-						return true
-					} // queen
+						isAttacker = true
+					}
 					if a == "b" && (v[0] != 0 && v[1] != 0) {
-						return true
-					} // diagonal path
+						isAttacker = true
+					}
 					if a == "r" && (v[0] == 0 || v[1] == 0) {
-						return true
-					} // straight path
+						isAttacker = true
+					}
 				}
+
+				if isAttacker {
+					return true
+				}
+				break // enemy piece blocks the line, even if it doesn't attack
 			}
 
 			s += 1

--- a/backend/simpleboard/internal/handler/dashboard.go
+++ b/backend/simpleboard/internal/handler/dashboard.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"net/http"
+	"simpleboard/internal/auth"
+	"simpleboard/internal/repository"
+	"simpleboard/pkg/db"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Dashboard returns stats for the authenticated user.
+// Guests are not supported — a registered account is required.
+//
+// Response shape (for frontend alignment):
+//
+//	{
+//	  "user_id":        uint,
+//	  "username":       string,
+//	  "total_games":    int,
+//	  "wins":           int,
+//	  "losses":         int,
+//	  "win_rate":       float64,   // 0.0–1.0; 0 if no games played
+//	  "current_streak": int,
+//	  "longest_streak": int
+//	}
+func Dashboard(c *gin.Context) {
+	claims := auth.GetClaims(c)
+	if claims == nil || claims.UserID == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "registered account required"})
+		return
+	}
+
+	var user repository.User
+	if err := db.DB.First(&user, *claims.UserID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	winRate := 0.0
+	if user.TotalGames > 0 {
+		winRate = float64(user.Wins) / float64(user.TotalGames)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"user_id":        user.UserID,
+		"username":       user.Username,
+		"total_games":    user.TotalGames,
+		"wins":           user.Wins,
+		"losses":         user.Losses,
+		"win_rate":       winRate,
+		"current_streak": user.CurrentStreak,
+		"longest_streak": user.LongestStreak,
+	})
+}

--- a/backend/simpleboard/internal/handler/dashboard.go
+++ b/backend/simpleboard/internal/handler/dashboard.go
@@ -5,25 +5,13 @@ import (
 	"simpleboard/internal/auth"
 	"simpleboard/internal/repository"
 	"simpleboard/pkg/db"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
-// Dashboard returns stats for the authenticated user.
+// Dashboard returns lifetime stats for the authenticated user.
 // Guests are not supported — a registered account is required.
-//
-// Response shape (for frontend alignment):
-//
-//	{
-//	  "user_id":        uint,
-//	  "username":       string,
-//	  "total_games":    int,
-//	  "wins":           int,
-//	  "losses":         int,
-//	  "win_rate":       float64,   // 0.0–1.0; 0 if no games played
-//	  "current_streak": int,
-//	  "longest_streak": int
-//	}
 func Dashboard(c *gin.Context) {
 	claims := auth.GetClaims(c)
 	if claims == nil || claims.UserID == nil {
@@ -51,5 +39,60 @@ func Dashboard(c *gin.Context) {
 		"win_rate":       winRate,
 		"current_streak": user.CurrentStreak,
 		"longest_streak": user.LongestStreak,
+	})
+}
+
+// gameHistoryEntry is what we return per game in the history list.
+// Kept flat and small — the frontend doesn't need the full board state here.
+type gameHistoryEntry struct {
+	GameID     string    `json:"game_id"`
+	Status     string    `json:"status"`
+	PlayedAs   string    `json:"played_as"`   // "w" or "b"
+	OpponentID uint      `json:"opponent_id"` // 0 if opponent was a guest
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// Games returns the authenticated user's game history, newest first.
+// Only finished or in-progress games where the user was a registered player are included.
+func Games(c *gin.Context) {
+	claims := auth.GetClaims(c)
+	if claims == nil || claims.UserID == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "registered account required"})
+		return
+	}
+
+	uid := *claims.UserID
+
+	// find all games where this user was white or black
+	var games []repository.Game
+	if err := db.DB.Where("white_player_id = ? OR black_player_id = ?", uid, uid).
+		Order("created_at DESC").
+		Find(&games).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "could not fetch games"})
+		return
+	}
+
+	history := make([]gameHistoryEntry, 0, len(games))
+	for _, g := range games {
+		entry := gameHistoryEntry{
+			GameID:    g.ID.String(),
+			Status:    g.Status,
+			CreatedAt: g.CreatedAt,
+			UpdatedAt: g.UpdatedAt,
+		}
+		if g.WhitePlayerID == uid {
+			entry.PlayedAs = "w"
+			entry.OpponentID = g.BlackPlayerID
+		} else {
+			entry.PlayedAs = "b"
+			entry.OpponentID = g.WhitePlayerID
+		}
+		history = append(history, entry)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"user_id": uid,
+		"games":   history,
 	})
 }

--- a/backend/simpleboard/internal/handler/dashboard.go
+++ b/backend/simpleboard/internal/handler/dashboard.go
@@ -11,7 +11,6 @@ import (
 )
 
 // Dashboard returns lifetime stats for the authenticated user.
-// Guests are not supported — a registered account is required.
 func Dashboard(c *gin.Context) {
 	claims := auth.GetClaims(c)
 	if claims == nil || claims.UserID == nil {
@@ -42,19 +41,17 @@ func Dashboard(c *gin.Context) {
 	})
 }
 
-// gameHistoryEntry is what we return per game in the history list.
-// Kept flat and small — the frontend doesn't need the full board state here.
+// gameHistoryEntry is returned per game in the history list
 type gameHistoryEntry struct {
 	GameID     string    `json:"game_id"`
 	Status     string    `json:"status"`
-	PlayedAs   string    `json:"played_as"`   // "w" or "b"
-	OpponentID uint      `json:"opponent_id"` // 0 if opponent was a guest
+	PlayedAs   string    `json:"played_as"`
+	OpponentID uint      `json:"opponent_id"`
 	CreatedAt  time.Time `json:"created_at"`
 	UpdatedAt  time.Time `json:"updated_at"`
 }
 
-// Games returns the authenticated user's game history, newest first.
-// Only finished or in-progress games where the user was a registered player are included.
+// Games returns the authenticated user's game history
 func Games(c *gin.Context) {
 	claims := auth.GetClaims(c)
 	if claims == nil || claims.UserID == nil {
@@ -64,7 +61,7 @@ func Games(c *gin.Context) {
 
 	uid := *claims.UserID
 
-	// find all games where this user was white or black
+	// find all games
 	var games []repository.Game
 	if err := db.DB.Where("white_player_id = ? OR black_player_id = ?", uid, uid).
 		Order("created_at DESC").

--- a/backend/simpleboard/internal/handler/game.go
+++ b/backend/simpleboard/internal/handler/game.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 // Game endpoint
@@ -294,6 +295,7 @@ func Game(c *gin.Context) {
 				entry.BlackRemainingMs = 0
 			}
 			db.DB.Save(&entry)
+			recordGameOutcome(&entry, entry.Status)
 		}
 
 		c.JSON(http.StatusOK, gin.H{
@@ -359,6 +361,7 @@ func Game(c *gin.Context) {
 		if timedOut, loser := timer.ApplyMove(&entry, time.Now()); timedOut {
 			entry.Status = timer.FlagFallStatus(loser).String()
 			db.DB.Save(&entry)
+			recordGameOutcome(&entry, entry.Status)
 			c.JSON(http.StatusOK, gin.H{
 				"message": "flag fall",
 				"state":   gameStatePayload(&entry, entry.WhiteRemainingMs, entry.BlackRemainingMs),
@@ -399,6 +402,11 @@ func Game(c *gin.Context) {
 
 		db.DB.Save(&entry)
 
+		// record outcome if this move ended the game
+		if game.Status != chess.InProgress {
+			recordGameOutcome(&entry, entry.Status)
+		}
+
 		c.JSON(http.StatusOK, gin.H{
 			"message": "move applied",
 			"state":   gameStatePayload(&entry, entry.WhiteRemainingMs, entry.BlackRemainingMs),
@@ -431,6 +439,29 @@ func gameStatePayload(entry *repository.Game, whiteMs, blackMs int64) gin.H {
 		"server_time":          time.Now().UTC(),
 		"created_at":           entry.CreatedAt,
 		"updated_at":           entry.UpdatedAt,
+	}
+}
+
+// recordGameOutcome bumps win/loss/total counts for registered players when a game ends.
+// Guests don't have persistent records, so they're skipped.
+func recordGameOutcome(entry *repository.Game, status string) {
+	bump := func(userID uint, fields map[string]interface{}) {
+		if userID == 0 {
+			return
+		}
+		db.DB.Model(&repository.User{}).Where("user_id = ?", userID).Updates(fields)
+	}
+
+	switch status {
+	case chess.WinWhite.String():
+		bump(entry.WhitePlayerID, map[string]interface{}{"total_games": gorm.Expr("total_games + 1"), "wins": gorm.Expr("wins + 1")})
+		bump(entry.BlackPlayerID, map[string]interface{}{"total_games": gorm.Expr("total_games + 1"), "losses": gorm.Expr("losses + 1")})
+	case chess.WinBlack.String():
+		bump(entry.BlackPlayerID, map[string]interface{}{"total_games": gorm.Expr("total_games + 1"), "wins": gorm.Expr("wins + 1")})
+		bump(entry.WhitePlayerID, map[string]interface{}{"total_games": gorm.Expr("total_games + 1"), "losses": gorm.Expr("losses + 1")})
+	case chess.Draw.String():
+		bump(entry.WhitePlayerID, map[string]interface{}{"total_games": gorm.Expr("total_games + 1")})
+		bump(entry.BlackPlayerID, map[string]interface{}{"total_games": gorm.Expr("total_games + 1")})
 	}
 }
 

--- a/backend/simpleboard/internal/handler/game.go
+++ b/backend/simpleboard/internal/handler/game.go
@@ -402,7 +402,7 @@ func Game(c *gin.Context) {
 
 		db.DB.Save(&entry)
 
-		// record outcome if this move ended the game
+		// record outcome if move ends the game
 		if game.Status != chess.InProgress {
 			recordGameOutcome(&entry, entry.Status)
 		}
@@ -442,8 +442,7 @@ func gameStatePayload(entry *repository.Game, whiteMs, blackMs int64) gin.H {
 	}
 }
 
-// recordGameOutcome bumps win/loss/total counts for registered players when a game ends.
-// Guests don't have persistent records, so they're skipped.
+// recordGameOutcome updates win/loss/total counts for registered players when a game ends.
 func recordGameOutcome(entry *repository.Game, status string) {
 	bump := func(userID uint, fields map[string]interface{}) {
 		if userID == 0 {

--- a/backend/simpleboard/internal/handler/login.go
+++ b/backend/simpleboard/internal/handler/login.go
@@ -35,7 +35,6 @@ func Login(c *gin.Context) {
 		return
 	}
 
-	// update daily streak on each new-day login
 	updateStreak(&user)
 
 	token, err := auth.NewUserToken(user.UserID, 24*time.Hour)
@@ -58,13 +57,11 @@ func Login(c *gin.Context) {
 	})
 }
 
-// updateStreak increments the user's daily streak if this is their first login today.
-// A new calendar day (midnight UTC) resets or extends the streak.
+// updateStreak checks for new daily login and increments the streak
 func updateStreak(user *repository.User) {
 	today := time.Now().UTC().Truncate(24 * time.Hour)
 	last := user.LastLoginDate.UTC().Truncate(24 * time.Hour)
 
-	// already logged in today — nothing to do
 	if last.Equal(today) {
 		return
 	}

--- a/backend/simpleboard/internal/handler/login.go
+++ b/backend/simpleboard/internal/handler/login.go
@@ -19,24 +19,29 @@ func Login(c *gin.Context) {
 		Password string `json:"password"`
 	}
 
+	// bad request; could not bind context into input struct
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
+	// get user
 	var user repository.User
 	if err := db.DB.Where("username = ?", input.Username).First(&user).Error; err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid username or password"})
 		return
 	}
 
+	// compare password hash
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(input.Password)); err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid username or password"})
 		return
 	}
 
+	// update the game streak number served in the response
 	updateStreak(&user)
 
+	// serve new login token
 	token, err := auth.NewUserToken(user.UserID, 24*time.Hour)
 	if err != nil {
 		log.Printf("token creation failed for user %d: %v", user.UserID, err)
@@ -44,6 +49,7 @@ func Login(c *gin.Context) {
 		return
 	}
 
+	// successfully logged in, serve token
 	c.JSON(http.StatusOK, gin.H{
 		"message": "login successful",
 		"token":   token,

--- a/backend/simpleboard/internal/handler/login.go
+++ b/backend/simpleboard/internal/handler/login.go
@@ -1,9 +1,8 @@
 package handler
 
 import (
-	"fmt"
+	"log"
 	"net/http"
-	//"simpleboard/internal/domain"
 	"simpleboard/internal/auth"
 	"simpleboard/internal/repository"
 	"simpleboard/pkg/db"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/bcrypt"
-	//"simpleboard/pkg/response"
 )
 
 // Logs a user in with username and password
@@ -21,41 +19,67 @@ func Login(c *gin.Context) {
 		Password string `json:"password"`
 	}
 
-	// bad request; could not bind context into input struct
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	// get user
 	var user repository.User
 	if err := db.DB.Where("username = ?", input.Username).First(&user).Error; err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid username or password"})
 		return
 	}
 
-	// compare password hash
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(input.Password)); err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid username or password"})
 		return
 	}
 
-	// serve new login token
+	// update daily streak on each new-day login
+	updateStreak(&user)
+
 	token, err := auth.NewUserToken(user.UserID, 24*time.Hour)
 	if err != nil {
-		fmt.Print(err.Error())
+		log.Printf("token creation failed for user %d: %v", user.UserID, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "could not create token"})
 		return
 	}
 
-	// user successfully logged in
 	c.JSON(http.StatusOK, gin.H{
 		"message": "login successful",
 		"token":   token,
 		"user": gin.H{
-			"user_id":  user.UserID,
-			"username": user.Username,
-			"email":    user.Email,
+			"user_id":        user.UserID,
+			"username":       user.Username,
+			"email":          user.Email,
+			"current_streak": user.CurrentStreak,
+			"longest_streak": user.LongestStreak,
 		},
 	})
+}
+
+// updateStreak increments the user's daily streak if this is their first login today.
+// A new calendar day (midnight UTC) resets or extends the streak.
+func updateStreak(user *repository.User) {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	last := user.LastLoginDate.UTC().Truncate(24 * time.Hour)
+
+	// already logged in today — nothing to do
+	if last.Equal(today) {
+		return
+	}
+
+	yesterday := today.Add(-24 * time.Hour)
+	if last.Equal(yesterday) {
+		user.CurrentStreak++ // kept the streak alive
+	} else {
+		user.CurrentStreak = 1 // gap or first ever login
+	}
+
+	if user.CurrentStreak > user.LongestStreak {
+		user.LongestStreak = user.CurrentStreak
+	}
+	user.LastLoginDate = today
+
+	db.DB.Save(user)
 }

--- a/backend/simpleboard/internal/repository/user_model.go
+++ b/backend/simpleboard/internal/repository/user_model.go
@@ -1,14 +1,21 @@
 package repository
 
-import (
-// "fmt"
-)
+import "time"
 
 // User is an instance of a registered user
-// Stores user details and login credentials
 type User struct {
 	UserID   uint   `gorm:"uniqueIndex;primaryKey;autoIncrement"`
 	Username string `gorm:"uniqueIndex;not null" json:"username"`
 	Email    string `gorm:"uniqueIndex;not null" json:"email"`
 	Password string `json:"password"`
+
+	// daily streak
+	LastLoginDate time.Time `json:"last_login_date"`
+	CurrentStreak int       `json:"current_streak"`
+	LongestStreak int       `json:"longest_streak"`
+
+	// lifetime game record
+	TotalGames int `json:"total_games"`
+	Wins       int `json:"wins"`
+	Losses     int `json:"losses"`
 }

--- a/backend/simpleboard/internal/repository/user_model.go
+++ b/backend/simpleboard/internal/repository/user_model.go
@@ -2,20 +2,18 @@ package repository
 
 import "time"
 
-// User is an instance of a registered user
+// User is an instance of a registered user;
+// Also stores readily available information on user
+// game statistics
 type User struct {
-	UserID   uint   `gorm:"uniqueIndex;primaryKey;autoIncrement"`
-	Username string `gorm:"uniqueIndex;not null" json:"username"`
-	Email    string `gorm:"uniqueIndex;not null" json:"email"`
-	Password string `json:"password"`
-
-	// daily streak
+	UserID        uint      `gorm:"uniqueIndex;primaryKey;autoIncrement"`
+	Username      string    `gorm:"uniqueIndex;not null" json:"username"`
+	Email         string    `gorm:"uniqueIndex;not null" json:"email"`
+	Password      string    `json:"password"`
 	LastLoginDate time.Time `json:"last_login_date"`
 	CurrentStreak int       `json:"current_streak"`
 	LongestStreak int       `json:"longest_streak"`
-
-	// lifetime game record
-	TotalGames int `json:"total_games"`
-	Wins       int `json:"wins"`
-	Losses     int `json:"losses"`
+	TotalGames    int       `json:"total_games"`
+	Wins          int       `json:"wins"`
+	Losses        int       `json:"losses"`
 }


### PR DESCRIPTION
Adds user engagement tracking

- Daily login streak counter (UTC-midnight)
- Game statistics recording (wins/losses/total games)
- GET /api/dashboard - returns user stats including win rate and streaks
- GET /api/games - returns user's game history
- Updated /api/login response to include streak fields
- Updated README with new api info
- Extended User model with streak and game stat fields