### PR TITLE
Add timer to game frontend

### DIFF
--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -3,6 +3,14 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app';
 
 describe('AppComponent', () => {
+    const localStorage = {
+      getItem: (_key: string) => {
+        return "1";
+      }
+    }
+
+  Object.defineProperty(window, 'localStorage', { value:  localStorage });
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent, RouterTestingModule.withRoutes([])],

--- a/frontend/src/app/features/auth/login/login.spec.ts
+++ b/frontend/src/app/features/auth/login/login.spec.ts
@@ -6,6 +6,14 @@ describe('LoginComponent', () => {
   let fixture: ComponentFixture<LoginComponent>;
 
   beforeEach(async () => {
+    const localStorage = {
+      getItem: (_key: string) => {
+        return "1";
+      }
+    }
+
+    Object.defineProperty(window, 'localStorage', { value:  localStorage });
+
     await TestBed.configureTestingModule({
       imports: [LoginComponent]
     }).compileComponents();

--- a/frontend/src/app/features/game/components/board/board.css
+++ b/frontend/src/app/features/game/components/board/board.css
@@ -12,6 +12,16 @@
   padding: 5px;
 }
 
+#game-timer {
+  display: block;
+  max-width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
+  height: 20px;
+  padding: 5px;
+  font-size: 20px;
+}
+
 .board-square {
     width: 100%;
     height: 100%;

--- a/frontend/src/app/features/game/components/board/board.html
+++ b/frontend/src/app/features/game/components/board/board.html
@@ -1,4 +1,7 @@
 <!-- Base board layout -->
+@if (boardTimerObservable$ | async; as timer) {
+  <span id="game-timer">{{ getTimerText(timer) }}</span>
+}
 <div id="board" #board>
     @if (boardPiecesObservable$ | async; as piecesArray) {
         <!-- Squares -->

--- a/frontend/src/app/features/game/components/board/board.spec.ts
+++ b/frontend/src/app/features/game/components/board/board.spec.ts
@@ -12,6 +12,14 @@ describe('Board', () => {
   let httpMock: HttpTestingController;
 
   beforeEach(async () => {
+    const localStorage = {
+      getItem: (_key: string) => {
+        return "1";
+      }
+    }
+
+    Object.defineProperty(window, 'localStorage', { value:  localStorage });
+
     await TestBed.configureTestingModule({
       imports: [Board],
       providers: [

--- a/frontend/src/app/features/game/components/board/board.ts
+++ b/frontend/src/app/features/game/components/board/board.ts
@@ -29,12 +29,12 @@ export class Board {
 
   ngOnInit() {
     const userId = Number(this.authService.userId());
-    this.stateService.boardLoad(Number(this.gameId), userId).subscribe();
+    this.stateService.boardLoad(this.gameId, userId).subscribe();
   }
 
   onPieceMoved(piece: ChessPiece, target: Position) {
     const userId = Number(this.authService.userId());
-    this.stateService.updatePiecePosition(Number(this.gameId), userId, piece, target).subscribe();
+    this.stateService.updatePiecePosition(this.gameId, userId, piece, target).subscribe();
   }
 
   isDarkSquare(i: number): boolean {

--- a/frontend/src/app/features/game/components/board/board.ts
+++ b/frontend/src/app/features/game/components/board/board.ts
@@ -24,8 +24,10 @@ export class Board {
 
   boardPieces: Signal<ChessPiece[]> = this.stateService.pieces;
   side: Signal<PlayerColor> = this.stateService.userColor;
+  boardTimer: Signal<number> = this.stateService.timerRemainingMs;
   boardPiecesObservable$ = toObservable(this.boardPieces);
   sideObservable$ = toObservable(this.side);
+  boardTimerObservable$ = toObservable(this.boardTimer);
 
   ngOnInit() {
     const userId = Number(this.authService.userId());
@@ -41,5 +43,10 @@ export class Board {
     const row = Math.floor(i / 8)
     const col = i % 8;
     return (row + col) % 2 !== 0
+  }
+
+  getTimerText(i: number): string {
+    const wholeNum = Math.round(i / 1000);
+    return `Your Time: ${wholeNum}s`
   }
 }

--- a/frontend/src/app/features/game/game.spec.ts
+++ b/frontend/src/app/features/game/game.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
 
 import { Game } from './game';
 import { API_ENDPOINT } from '../../app.constants'
@@ -12,11 +13,20 @@ describe('Game', () => {
   let httpMock: HttpTestingController;
 
   beforeEach(async () => {
+    const localStorage = {
+      getItem: (_key: string) => {
+        return "1";
+      }
+    }
+
+    Object.defineProperty(window, 'localStorage', { value:  localStorage });
+
     await TestBed.configureTestingModule({
       imports: [Game],
       providers: [
         provideHttpClient(),
-        provideHttpClientTesting()
+        provideHttpClientTesting(),
+        provideRouter([{path: 'game/:id', component: Game}])
       ]
     })
     .compileComponents();

--- a/frontend/src/app/features/game/services/board-state-service.spec.ts
+++ b/frontend/src/app/features/game/services/board-state-service.spec.ts
@@ -61,7 +61,7 @@ describe('BoardStateService', () => {
   });
 
   it('should load state from request', () => {
-    service.boardLoad(0, 1).subscribe(_ => {
+    service.boardLoad("0", 1).subscribe(_ => {
       expect(service.userColor()).toBe('b');
       expect(service.fullmoveNum()).toBe(1);
 

--- a/frontend/src/app/features/game/services/board-state-service.ts
+++ b/frontend/src/app/features/game/services/board-state-service.ts
@@ -11,7 +11,7 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 
 type GameRequest = {
   action: string;
-  game_id: number;
+  game_id: string;
   player_id: number;
   move: string;
 }
@@ -60,7 +60,7 @@ export class BoardStateService {
   private _nextMoves = signal<Move[]>([]);
   private _gameStatus = signal<GameStatus>("Waiting");
   private _playerId = signal<number>(-1);
-  private _gameId = signal<number>(-1);
+  private _gameId = signal<string>('');
   private _timerRemainingMs = signal<number>(-1);
   private _pollBackend = signal<boolean>(false);
   private _gameTimerRunning = signal<boolean>(false);
@@ -83,7 +83,7 @@ export class BoardStateService {
   private poll$ = toObservable(this.pollBackend).pipe(
     switchMap(p => p ? timer(0, BACKEND_PING_RATE_MS) : EMPTY),
     switchMap(() => {
-      if (this.playerId() != -1 && this.gameId() != -1) {
+      if (this.playerId() != -1 && this.gameId() != '') {
         return this.boardLoad(this.gameId(), this.playerId())
       } else {
         return EMPTY;
@@ -96,7 +96,7 @@ export class BoardStateService {
     // If timer is runing (p), wait one second, update GUI signal
     switchMap(p => p ? timer(0, 1000) : EMPTY),
     switchMap(() => {
-      if (this.playerId() != -1 && this.gameId() != -1) {
+      if (this.playerId() != -1 && this.gameId() != '') {
         this._timerRemainingMs.update(prevTime => prevTime - 1000);
         console.log(`tick ${this.timerRemainingMs()}`);
       }
@@ -114,7 +114,7 @@ export class BoardStateService {
   /**
    * @returns Observable<void>, so the caller may make use of the completion event after request completion and state update.
    */
-  boardLoad(gameId: number, playerId: number): Observable<void> {
+  boardLoad(gameId: string, playerId: number): Observable<void> {
     // Load initial state
     const req: GameRequest = {
       action:"state",
@@ -217,7 +217,7 @@ export class BoardStateService {
     );
   }
 
-  updatePiecePosition(gameId: number, playerId: number, piece: ChessPiece, newPos: Position): Observable<void> {
+  updatePiecePosition(gameId: string, playerId: number, piece: ChessPiece, newPos: Position): Observable<void> {
     let captureChar = '';
     for (const piece of this._pieces()) {
       if (positionsEqual(piece.position, newPos))

--- a/frontend/src/app/features/game/services/board-state-service.ts
+++ b/frontend/src/app/features/game/services/board-state-service.ts
@@ -98,7 +98,10 @@ export class BoardStateService {
     switchMap(() => {
       if (this.playerId() != -1 && this.gameId() != '') {
         this._timerRemainingMs.update(prevTime => prevTime - 1000);
-        console.log(`tick ${this.timerRemainingMs()}`);
+
+        if (this.timerRemainingMs() < 0) {
+          return this.boardLoad(this.gameId(), this.playerId())
+        }
       }
 
       return EMPTY;
@@ -202,12 +205,15 @@ export class BoardStateService {
           }
 
           this._gameStatus.update(_p => parseGameStatus(resp.state.status));
-          if (this.isOwnMove()) {
+          if (this.isOwnMove() && resp.state.status == 'InProgress') {
             this._gameTimerRunning.update(_ => true);
             this._pollBackend.update(_ => false);
-          } else {
+          } else if (resp.state.status == 'InProgress') {
             this._gameTimerRunning.update(_ => false);
             this._pollBackend.update(_ => true);
+          } else {
+            this._gameTimerRunning.update(_ => false);
+            this._pollBackend.update(_ => false);
           }
 
           return;

--- a/frontend/src/app/features/game/services/board-state-service.ts
+++ b/frontend/src/app/features/game/services/board-state-service.ts
@@ -8,6 +8,7 @@ import { API_ENDPOINT, BACKEND_PING_RATE_MS } from '../../../app.constants';
 import { GameStatus, parseGameStatus } from './BoardState';
 
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+
 type GameRequest = {
   action: string;
   game_id: number;
@@ -25,8 +26,13 @@ type GameApiResponse = {
   side: string;
   black_player_id: string;
   white_player_id: string;
-  next_moves: string[]
-  prev_moves: string[]
+  next_moves: string[];
+  prev_moves: string[];
+  white_remaining_ms: number;
+  black_remaining_ms: number;
+  last_move_at: string;
+  server_time: string;
+  updated_at: string;
 }
 
 type GameApiError = {
@@ -55,7 +61,9 @@ export class BoardStateService {
   private _gameStatus = signal<GameStatus>("Waiting");
   private _playerId = signal<number>(-1);
   private _gameId = signal<number>(-1);
+  private _timerRemainingMs = signal<number>(-1);
   private _pollBackend = signal<boolean>(false);
+  private _gameTimerRunning = signal<boolean>(false);
 
   readonly pieces = this._pieces.asReadonly();
   readonly isOwnMove = this._isOwnMove.asReadonly();
@@ -68,7 +76,9 @@ export class BoardStateService {
   readonly gameStatus = this._gameStatus.asReadonly();
   readonly playerId = this._playerId.asReadonly();
   readonly gameId = this._gameId.asReadonly();
+  readonly timerRemainingMs = this._timerRemainingMs.asReadonly();
   private readonly pollBackend = this._pollBackend.asReadonly();
+  private readonly gameTimerRunning = this._gameTimerRunning.asReadonly();
 
   private poll$ = toObservable(this.pollBackend).pipe(
     switchMap(p => p ? timer(0, BACKEND_PING_RATE_MS) : EMPTY),
@@ -82,8 +92,23 @@ export class BoardStateService {
     takeUntilDestroyed()
   )
 
+  private gameTimer$ = toObservable(this.gameTimerRunning).pipe(
+    // If timer is runing (p), wait one second, update GUI signal
+    switchMap(p => p ? timer(0, 1000) : EMPTY),
+    switchMap(() => {
+      if (this.playerId() != -1 && this.gameId() != -1) {
+        this._timerRemainingMs.update(prevTime => prevTime - 1000);
+        console.log(`tick ${this.timerRemainingMs()}`);
+      }
+
+      return EMPTY;
+    }),
+    takeUntilDestroyed()
+  )
+
   constructor() {
     this.poll$.subscribe();
+    this.gameTimer$.subscribe();
   }
 
   /**
@@ -163,10 +188,26 @@ export class BoardStateService {
             throw new Error(`No piece found for target move ${move_str}`);
           }));
 
+         const serverTimeStr = resp.state.server_time;
+          const serverTime = new Date(serverTimeStr + "Z");
+          console.log(serverTime)
+
+          const timeDelta = Date.now() - serverTime.getTime();
+
+          if (this.userColor() == 'w') {
+            const trueRemaining = resp.state.white_remaining_ms;
+            this._timerRemainingMs.update(_ => trueRemaining - timeDelta);
+          } else if (this.userColor() == 'b') {
+            const trueRemaining = resp.state.black_remaining_ms;
+            this._timerRemainingMs.update(_ => trueRemaining - timeDelta);
+          }
+
           this._gameStatus.update(_p => parseGameStatus(resp.state.status));
           if (this.isOwnMove()) {
+            this._gameTimerRunning.update(_ => true);
             this._pollBackend.update(_ => false);
           } else {
+            this._gameTimerRunning.update(_ => false);
             this._pollBackend.update(_ => true);
           }
 

--- a/frontend/src/app/features/game/services/board-state-service.ts
+++ b/frontend/src/app/features/game/services/board-state-service.ts
@@ -189,8 +189,7 @@ export class BoardStateService {
           }));
 
          const serverTimeStr = resp.state.server_time;
-          const serverTime = new Date(serverTimeStr + "Z");
-          console.log(serverTime)
+          const serverTime = new Date(serverTimeStr);
 
           const timeDelta = Date.now() - serverTime.getTime();
 


### PR DESCRIPTION
Closes #91 and #88.
Adds player turn timer to game state that re-syncs with server on state/move pings.